### PR TITLE
chore: Remove unused region list

### DIFF
--- a/eksupgrade/cli.py
+++ b/eksupgrade/cli.py
@@ -44,34 +44,6 @@ Display the eksupgrade version:
   eksupgrade --version
 """
 
-    regions_list: List[str] = [
-        "af-south-1",
-        "eu-north-1",
-        "ap-south-1",
-        "eu-west-3",
-        "eu-west-2",
-        "eu-south-1",
-        "eu-west-1",
-        "ap-northeast-3",
-        "ap-northeast-2",
-        "me-central-1",
-        "me-south-1",
-        "ap-northeast-1",
-        "sa-east-1",
-        "ca-central-1",
-        "ap-east-1",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ap-southeast-3",
-        "eu-central-1",
-        "us-east-1",
-        "us-east-2",
-        "us-west-1",
-        "us-west-2",
-        "us-gov-east-1",
-        "us-gov-west-1",
-    ]
-
     parser = argparse.ArgumentParser(
         description="Amazon EKS cluster upgrade",
         epilog=example_text,
@@ -79,7 +51,7 @@ Display the eksupgrade version:
     )
     parser.add_argument("name", help="Cluster Name")
     parser.add_argument("version", help="new version which you want to update")
-    parser.add_argument("region", help=f"Give the region name {', '.join(regions_list)}")
+    parser.add_argument("region", help="The AWS region where the cluster resides")
     parser.add_argument(
         "--pass_vpc", action="store_true", default=False, help="this --pass-vpc will skip the vpc cni upgrade"
     )


### PR DESCRIPTION
**Issue number:** #38

## Summary

### Changes

The goal of this PR is to eliminate the unnecessary, hardcoded region list used for outputting eligible regions in the help text.

### User experience

No real change -- user will need to lookup eligible regions, but they should already know where a cluster resides (and it be valid, right?)

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
