### PR TITLE
ci: Add GitHub action to publish to PyPi and GH on tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,49 @@
+name: 'Publish Release'
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Dependencies
+        uses: './.github/actions/dep-setup'
+        with:
+          python-version: '3.10'
+
+      - name: Run Safety Check
+        run: poetry poe safety
+
+      - name: Get Python Module Version
+        run: |
+          MODULE_VERSION=$(poetry version --short)
+          echo "MODULE_VERSION=$MODULE_VERSION" >> $GITHUB_ENV
+
+      - name: Verify Versions Match
+        run: |
+          TAG_VERSION=$(git describe HEAD --tags --abbrev=0)
+          echo "Git Tag Version: $TAG_VERSION"
+          echo "Python Module Version: $MODULE_VERSION"
+          if [[ "$TAG_VERSION" != "$MODULE_VERSION" ]]; then exit 1; fi
+
+      - name: Publish to PyPi
+        run: poetry publish --build
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          files: |
+            dist/eksupgrade-${{env.MODULE_VERSION}}-py3-none-any.whl
+            dist/eksupgrade-${{env.MODULE_VERSION}}.tar.gz


### PR DESCRIPTION
**Issue number:** N/A

## Summary

### Changes

Add automatic build / publish to pypi / release on GH on tag actions.

### User experience

Maintainer pushes tag to GH resulting in:

- Execution of `safety` CVE checks on dependencies (fail if CVEs are found)
- Compare the current git tag (that triggered the action) against the current python module version (fail if they don't match)
- Build python module and publish to PyPi
- Publish GitHub Release (attaching the build wheel and source tar.gz files and auto-generating the release notes from GH API).

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
