### PR TITLE
fix: updating format specifier addressing issue#49

### DIFF
--- a/eksupgrade/src/latest_ami.py
+++ b/eksupgrade/src/latest_ami.py
@@ -14,15 +14,15 @@ def get_latest_ami(cluster_version: str, instance_type: str, image_to_search: st
     client = boto3.client("ec2", region_name=region)
 
     if "Amazon Linux 2" in instance_type:
-        names = [f"/aws/service/eks/optimized-ami/{cluster_version: str}/amazon-linux-2/recommended/image_id"]
+        names = [f"/aws/service/eks/optimized-ami/{cluster_version: s}/amazon-linux-2/recommended/image_id"]
     elif "Windows" in instance_type:
-        names = [f"/aws/service/ami-windows-latest/{image_to_search}-{cluster_version: str}/image_id"]
+        names = [f"/aws/service/ami-windows-latest/{image_to_search}-{cluster_version: s}/image_id"]
     elif "bottlerocket" in instance_type.lower():
-        names = [f"/aws/service/bottlerocket/aws-k8s-{cluster_version: str}/x86_64/latest/image_id"]
+        names = [f"/aws/service/bottlerocket/aws-k8s-{cluster_version: s}/x86_64/latest/image_id"]
     elif "Ubuntu" in instance_type:
         filters = [
             {"Name": "owner-id", "Values": ["099720109477"]},
-            {"Name": "name", "Values": [f"ubuntu-eks/k8s_{cluster_version: str}*"]},
+            {"Name": "name", "Values": [f"ubuntu-eks/k8s_{cluster_version: s}*"]},
             {"Name": "is-public", "Values": ["true"]},
         ]
         response = client.describe_images(Filters=filters)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number: #49 **

## Summary

### Changes

Updates the format specifier to fix the error when running eksupgrade on a cluster.

```
INFO:eksupgrade.starter:The Image Type Detected = ***
ERROR:eksupgrade.starter:Exception encountered in main method - Error: Invalid format specifier
```
The changes were tested with the local version of the module and updated the additional format specifiers in `latest_ami.py`

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [X] I have performed a self-review of this change
- [X] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
