### PR TITLE
fix: Update K8s eviction api from beta

### DIFF
--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -153,7 +153,7 @@ def drain_nodes(cluster_name, node_name, forced, region) -> Optional[str]:
                         i.metadata.name, i.metadata.namespace, grace_period_seconds=0, body=client.V1DeleteOptions()
                     )
                 else:
-                    eviction_body = client.models.v1beta1_eviction.V1beta1Eviction(
+                    eviction_body = client.models.v1_eviction.V1Eviction(
                         metadata=client.V1ObjectMeta(name=i.metadata.name, namespace=i.metadata.namespace)
                     )
                     core_v1_api.create_namespaced_pod_eviction(

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -21,7 +21,7 @@ except ImportError:
     from functools import lru_cache as cache
 
 try:
-    from Kubernetes.client.models.v1beta1_eviction import V1beta1Eviction as V1Eviction
+    from kubernetes.client.models.v1beta1_eviction import V1beta1Eviction as V1Eviction
 except ImportError:
     from Kubernetes.client.models.v1_eviction import V1Eviction
 

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -23,7 +23,7 @@ except ImportError:
 try:
     from kubernetes.client.models.v1beta1_eviction import V1beta1Eviction as V1Eviction
 except ImportError:
-    from Kubernetes.client.models.v1_eviction import V1Eviction
+    from kubernetes.client.models.v1_eviction import V1Eviction
 
 import boto3
 import yaml

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -20,6 +20,11 @@ try:
 except ImportError:
     from functools import lru_cache as cache
 
+try:
+    from Kubernetes.client.models.v1beta1_eviction import V1beta1Eviction as V1Eviction
+except ImportError:
+    from Kubernetes.client.models.v1_eviction import V1Eviction
+
 import boto3
 import yaml
 from botocore.signers import RequestSigner
@@ -153,7 +158,7 @@ def drain_nodes(cluster_name, node_name, forced, region) -> Optional[str]:
                         i.metadata.name, i.metadata.namespace, grace_period_seconds=0, body=client.V1DeleteOptions()
                     )
                 else:
-                    eviction_body = client.models.v1_eviction.V1Eviction(
+                    eviction_body = V1Eviction(
                         metadata=client.V1ObjectMeta(name=i.metadata.name, namespace=i.metadata.namespace)
                     )
                     core_v1_api.create_namespaced_pod_eviction(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

**Issue number:#51**

## Summary

### Changes

- Update the Eviction api used from `V1beta1Eviction` to `V1Eviction`
- This change in api is reference to the version pinned with the poetry lock we have on the repo. https://github.com/kubernetes-client/python/tree/v24.2.0/kubernetes/client/models
- https://github.com/aws-samples/eks-cluster-upgrade/blob/main/poetry.lock#L1086

This has been with two version upgrades : `1.21` -> `1.22` , `1.22`-> `1.23`

- Updated to handle both versions eventhough poetry lock is on 24.2.0

### User experience

Fixes the issue#51 with the cluster upgrade when the utility attempts to drain nodes.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [X] I have performed a self-review of this change
- [X] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
