### PR TITLE
chore: Fix PR template to automatically link issues for closing on merge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,9 @@
 <!-- markdownlint-disable MD041 MD043 -->
 
-**Issue number:**
-
 ## Summary
+
+
+Resolves: #<PROVIDE>
 
 ### Changes
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
- Fix PR template to automatically link issues for closing on merge. If there is a `Resolves #xxx` or `Closes #xxx` within the template, GitHub will automatically link the issue to this PR and ensure its closed when merged

### Changes

- Change PR template to ensure issues are automatically linked 

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [ ] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
