### PR TITLE
fix: Add eks and base data models

### DIFF
--- a/eksupgrade/models/base.py
+++ b/eksupgrade/models/base.py
@@ -1,0 +1,61 @@
+"""Define the base models to be used across the EKS upgrade tool."""
+from __future__ import annotations
+
+import logging
+from abc import ABC
+from dataclasses import dataclass, field
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+import boto3
+
+if TYPE_CHECKING:
+    from mypy_boto3_sts import STSClient
+else:
+    STSClient = object
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BaseResource(ABC):
+    """Define the base resource for the EKS cluster upgrade tool."""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of this object."""
+        try:
+            return self.__dict__
+        except Exception as error:
+            logger.error("Exception encountered attempting to convert object to dictionary! Error: %s", error)
+        return {}
+
+
+@dataclass
+class AwsResource(BaseResource, ABC):
+    """Define the abstract AWS base resource class."""
+
+    arn: str
+    resource_id: str = ""
+    tags: Dict[str, str] = field(default_factory=lambda: ({}))
+
+    def _get_boto_client(self, service: str, **kwargs):
+        """Get a boto client."""
+        return boto3.client(service, **kwargs)
+
+    @cached_property
+    def sts_client(self) -> STSClient:
+        """Get a boto STS client."""
+        boto_kwargs: Dict[str, Any] = {}
+        region: Optional[str] = getattr(self, "region", "")
+
+        if region:
+            boto_kwargs["region_name"] = region
+
+        return self._get_boto_client(service="sts", **boto_kwargs)
+
+
+@dataclass
+class AwsRegionResource(AwsResource, ABC):
+    """Define the abstract AWS region specific base resource class."""
+
+    region: str = ""

--- a/eksupgrade/models/base.py
+++ b/eksupgrade/models/base.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import boto3
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from mypy_boto3_sts import STSClient
 else:
     STSClient = object
@@ -23,11 +23,7 @@ class BaseResource(ABC):
 
     def to_dict(self) -> Dict[str, Any]:
         """Return the dictionary representation of this object."""
-        try:
-            return self.__dict__
-        except Exception as error:
-            logger.error("Exception encountered attempting to convert object to dictionary! Error: %s", error)
-        return {}
+        return self.__dict__
 
 
 @dataclass

--- a/eksupgrade/models/eks.py
+++ b/eksupgrade/models/eks.py
@@ -234,7 +234,7 @@ class Cluster(EksResource):
     def cluster_identifier(self) -> str:
         """Return the preferred identifier for the cluster.
 
-        If the cluster is an outpost, use the resource ID.
+        If the cluster is a local cluster deployed on AWS Outposts, the resource ID must be used.
         If not, use the cluster name.
 
         """

--- a/eksupgrade/models/eks.py
+++ b/eksupgrade/models/eks.py
@@ -1,0 +1,356 @@
+"""Define the models to be used across the EKS upgrade tool."""
+from __future__ import annotations
+
+import base64
+import datetime
+import logging
+from abc import ABC
+from dataclasses import dataclass, field
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+import boto3
+from kubernetes import client as k8s_client
+from kubernetes import config as k8s_config
+
+from .base import AwsRegionResource
+
+try:
+    from functools import cache
+except ImportError:
+    from functools import lru_cache as cache
+
+if TYPE_CHECKING:
+    from mypy_boto3_eks.client import EKSClient
+    from mypy_boto3_eks.type_defs import (
+        AddonInfoTypeDef,
+        AddonTypeDef,
+        ClusterTypeDef,
+        DescribeAddonResponseTypeDef,
+        DescribeClusterResponseTypeDef,
+        UpdateAddonResponseTypeDef,
+    )
+else:
+    AddonInfoTypeDef = object
+    AddonTypeDef = object
+    ClusterTypeDef = object
+    DescribeAddonResponseTypeDef = object
+    DescribeClusterResponseTypeDef = object
+    EKSClient = object
+    UpdateAddonResponseTypeDef = object
+
+logger = logging.getLogger(__name__)
+
+TOKEN_PREFIX: str = "k8s-aws-v1"
+TOKEN_HEADER_KEY: str = "x-k8s-aws-id"
+
+
+def requires_cluster(function):
+    """Decorate methods to require a cluster attribute."""
+
+    def wrapper(self, *args, **kwargs):
+        if not self.cluster:
+            logger.error(
+                "Unable to use method: %s without the cluster attribute! Pass a cluster to this child object!",
+                function.__name__,
+            )
+        return function(self, *args, **kwargs)
+
+    return wrapper
+
+
+@dataclass
+class EksResource(AwsRegionResource, ABC):
+    """Define the abstract EKS base resource class."""
+
+    name: str = ""
+    status: str = ""
+    version: str = ""
+
+    @cached_property
+    def eks_client(self) -> EKSClient:
+        """Get a boto EKS client."""
+        return self._get_boto_client(service="eks", region_name=self.region)
+
+    @cached_property
+    def core_api_client(self) -> Any:
+        """Get a Kubernetes Core client."""
+        return k8s_client.CoreV1Api()
+
+    @cached_property
+    def apps_api_client(self) -> Any:
+        """Get a Kubernetes Apps client."""
+        return k8s_client.AppsV1Api()
+
+
+@dataclass
+class ClusterAddon(EksResource):
+    """Define the Kubernetes Cluster Addon model."""
+
+    health: Dict[str, List[Any]] = field(default_factory=lambda: ({"issues": []}))
+    created_at: datetime.datetime = datetime.datetime.now()
+    modified_at: datetime.datetime = datetime.datetime.now()
+    service_account_role_arn: str = ""
+    publisher: str = ""
+    owner: str = ""
+    product_id: str = ""
+    product_url: str = ""
+    configuration_values: str = ""
+    cluster: Cluster = field(default_factory=lambda: Cluster(arn=""))
+
+    def __repr__(self) -> str:
+        """Return the string representation of a Cluster Addon."""
+        return f"<{self.__class__.__name__} - Name: {self.name} | Version: {self.version} | Last Status: {self.status}>"
+
+    @property
+    def addon_name(self) -> str:
+        """Return the addon name."""
+        return self.name
+
+    @classmethod
+    def get_addon(cls, addon: str, cluster: Cluster, region: str):
+        """Get the cluster addon details and build a ClusterAddon object."""
+        logger.debug("Getting cluster addon details...")
+        _temp_cluster = cls(arn="", region=region)
+        response: DescribeAddonResponseTypeDef = _temp_cluster.eks_client.describe_addon(
+            addonName=addon,
+            clusterName=cluster.name,
+        )
+        addon_data: AddonTypeDef = response["addon"]
+        addon_version: str = addon_data.get("addonVersion", "")
+        markplace_data = addon_data.get("marketplaceInformation", {})
+        logger.debug("Addon: %s - Current Version: %s - Cluster: %s", addon, addon_version, cluster.name)
+
+        return cls(
+            arn=addon_data.get("addonArn", ""),
+            name=addon_data.get("addonName", ""),
+            version=addon_version,
+            status=addon_data.get("status", ""),
+            health=addon_data.get("health", {}),
+            created_at=addon_data.get("createdAt", datetime.datetime.now()),
+            modified_at=addon_data.get("modifiedAt", datetime.datetime.now()),
+            tags=addon_data.get("tags", {}),
+            region=region,
+            service_account_role_arn=addon_data.get("serviceAccountRoleArn", ""),
+            publisher=addon_data.get("publisher", ""),
+            owner=addon_data.get("owner", ""),
+            product_id=markplace_data.get("productId", ""),
+            product_url=markplace_data.get("productUrl", ""),
+            cluster=cluster,
+        )
+
+    @cached_property
+    def _addon_update_kwargs(self) -> Dict[str, Any]:
+        """Get kwargs for subsequent update to addon."""
+        kwargs: Dict[str, Any] = {}
+
+        if self.service_account_role_arn:
+            kwargs["serviceAccountRoleArn"] = self.service_account_role_arn
+        if self.configuration_values:
+            kwargs["configurationValues"] = self.configuration_values
+        return kwargs
+
+    @requires_cluster
+    def update_addon(self, version: str) -> UpdateAddonResponseTypeDef:
+        """Update the addon to the target version."""
+        logger.info("Updating the EKS cluster's %s add-on version via the EKS API...", self.name)
+        update_response: UpdateAddonResponseTypeDef = self.eks_client.update_addon(
+            clusterName=self.cluster.name,
+            addonName=self.name,
+            addonVersion=version,
+            resolveConflicts="OVERWRITE",
+            **self._addon_update_kwargs,
+        )
+        return update_response
+
+
+@dataclass
+class Cluster(EksResource):
+    """Define the Kubernetes Cluster model."""
+
+    certificate_authority_data: str = ""
+    identity_oidc_issuer: str = ""
+    endpoint: str = ""
+    role_arn: str = ""
+    platform_version: str = ""
+    secrets_key_arn: str = ""
+    cluster_logging_enabled: bool = False
+
+    def __repr__(self) -> str:
+        """Return the string representation of a Cluster."""
+        return f"<{self.__class__.__name__} - Name: {self.name} | Version: {self.version} | Last Status: {self.status}>"
+
+    def __post_init__(self) -> None:
+        """Perform the post initialization steps."""
+        self._register_k8s_aws_id_handlers()
+        self.load_config()
+
+    def _register_k8s_aws_id_handlers(self) -> None:
+        """Register the kubernetes AWS ID header handlers."""
+        self.sts_client.meta.events.register(
+            "provide-client-params.sts.GetCallerIdentity",
+            self._retrieve_k8s_aws_id,
+        )
+        self.sts_client.meta.events.register(
+            "before-sign.sts.GetCallerIdentity",
+            self._inject_k8s_aws_id_header,
+        )
+
+    def _retrieve_k8s_aws_id(self, params, context, **_) -> None:
+        """Retrieve the kubernetes AWS ID header for use in boto3 request headers."""
+        if TOKEN_HEADER_KEY in params:
+            context[TOKEN_HEADER_KEY] = params.pop(TOKEN_HEADER_KEY)
+            logger.debug("Retrieving cluster header %s: %s", TOKEN_HEADER_KEY, context[TOKEN_HEADER_KEY])
+
+    def _inject_k8s_aws_id_header(self, request, **_) -> None:
+        """Inject the kubernetes AWS ID header into boto3 request headers."""
+        if TOKEN_HEADER_KEY in request.context:
+            request.headers[TOKEN_HEADER_KEY] = request.context[TOKEN_HEADER_KEY]
+            logger.debug("Patching boto3 STS calls with cluster headers: %s", request.headers)
+
+    def _get_presigned_url(self, url_timeout: int = 60) -> str:
+        """Get the presigned URL."""
+        logger.debug("Generating the pre-signed url for get-caller-identity...")
+        return self.sts_client.generate_presigned_url(
+            "get_caller_identity",
+            Params={TOKEN_HEADER_KEY: self.cluster_identifier},
+            ExpiresIn=url_timeout,
+            HttpMethod="GET",
+        )
+
+    @cached_property
+    def _current_addons(self) -> List[str]:
+        """Return a list of addon names currently installed in the cluster."""
+        logger.debug("Getting the list of current cluster addons for cluster: %s...", self.name)
+        return self.eks_client.list_addons(clusterName=self.name).get("addons", [])
+
+    @property
+    def cluster_name(self) -> str:
+        """Return the cluster ID."""
+        return self.name
+
+    @property
+    def cluster_identifier(self) -> str:
+        """Return the preferred identifier for the cluster.
+
+        If the cluster is an outpost, use the resource ID.
+        If not, use the cluster name.
+
+        """
+        return self.resource_id or self.name
+
+    @cached_property
+    def addons(self) -> List[ClusterAddon]:
+        """Return a list of cluster addons currently setup in the cluster."""
+        logger.debug("Fetching Cluster Addons...")
+        return [ClusterAddon.get_addon(addon, self, self.region) for addon in self._current_addons]
+
+    def get_token(self) -> str:
+        """Generate a presigned url token to pass to client."""
+        logger.debug("Getting the pre-signed STS token...")
+        url = self._get_presigned_url()
+        suffix: str = base64.urlsafe_b64encode(url.encode("utf-8")).decode("utf-8").rstrip("=")
+        token = f"{TOKEN_PREFIX}.{suffix}"
+        return token
+
+    @property
+    def user_config(self) -> Dict[str, Union[str, List[Dict[str, Any]]]]:
+        """Get a configuration for the Kubernetes client library.
+
+        The credentials of the given portal user are used, access is restricted to the default namespace.
+
+        """
+        config_data: Dict[str, Union[str, List[Dict[str, Any]]]] = {
+            "current-context": self.cluster_name,
+            "contexts": [
+                {
+                    "name": self.cluster_name,
+                    "context": {
+                        "cluster": self.cluster_name,
+                        "user": self.arn,
+                    },
+                }
+            ],
+            "clusters": [
+                {
+                    "name": self.cluster_name,
+                    "cluster": {
+                        "certificate-authority-data": self.certificate_authority_data,
+                        "server": self.endpoint,
+                    },
+                }
+            ],
+            "users": [
+                {
+                    "name": self.arn,
+                    "user": {
+                        "token": self.get_token(),
+                    },
+                }
+            ],
+        }
+        return config_data
+
+    def load_config(self, user_config: Optional[Dict[str, Any]] = None) -> None:
+        """Load the Kubernetes configuration."""
+        logger.debug("Loading Kubernetes config from user config dictionary...")
+        user_config = user_config or self.user_config
+        k8s_config.load_kube_config_from_dict(user_config)
+        logger.debug("Loaded kubernetes config from user config!")
+
+    @classmethod
+    def get_cluster(cls, cluster_name: str, region: str):
+        """Get the cluster details and build a Cluster."""
+        logger.debug("Getting cluster details...")
+        eks_client = boto3.client("eks", region_name=region)
+
+        response: DescribeClusterResponseTypeDef = eks_client.describe_cluster(
+            name=cluster_name,
+        )
+        cluster_data: ClusterTypeDef = response["cluster"]
+
+        # If encryption config is present, use it to populate secrets ARN.
+        try:
+            _secrets_key_arn: str = cluster_data["encryptionConfig"][0]["provider"]["keyArn"]
+        except (KeyError, IndexError):
+            logger.debug("No secrets key ARN found for cluster... defaulting to empty string.")
+            _secrets_key_arn = ""
+
+        return cls(
+            arn=cluster_data.get("arn", ""),
+            name=cluster_data.get("name", ""),
+            resource_id=cluster_data.get("id", ""),
+            certificate_authority_data=cluster_data.get("certificateAuthority", {}).get("data", ""),
+            endpoint=cluster_data.get("endpoint", ""),
+            version=cluster_data.get("version", ""),
+            status=cluster_data.get("status", ""),
+            platform_version=cluster_data.get("platformVersion", ""),
+            role_arn=cluster_data.get("roleArn", ""),
+            identity_oidc_issuer=cluster_data.get("identity", {}).get("oidc", {}).get("issuer", ""),
+            secrets_key_arn=_secrets_key_arn,
+            region=region,
+        )
+
+    @cache
+    def get_available_addon_versions(self, kubernetes_version: str) -> List[AddonInfoTypeDef]:
+        """Get the available addon versions for the associated Kubernetes version."""
+        addon_versions: List[AddonInfoTypeDef] = self.eks_client.describe_addon_versions(
+            kubernetesVersion=kubernetes_version
+        ).get("addons", [])
+        return addon_versions
+
+    @cache
+    def get_versions_by_addon(self, addon: str, kubernetes_version: str) -> AddonInfoTypeDef:
+        """Get target addon versions."""
+        addon_versions: List[AddonInfoTypeDef] = self.get_available_addon_versions(kubernetes_version)
+        return next(item for item in addon_versions if item.get("addonName", "") == addon)
+
+    @cache
+    def get_default_version(self, addon: str, kubernetes_version: str) -> str:
+        """Get the EKS default version of the addon."""
+        addon_dict: AddonInfoTypeDef = self.get_versions_by_addon(addon, kubernetes_version)
+        return next(
+            item.get("addonVersion", "")
+            for item in addon_dict.get("addonVersions", [])
+            if item.get("compatibilities", [])[0].get("defaultVersion", False) is True
+        )

--- a/eksupgrade/models/eks.py
+++ b/eksupgrade/models/eks.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     from functools import lru_cache as cache
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from mypy_boto3_eks.client import EKSClient
     from mypy_boto3_eks.type_defs import (
         AddonInfoTypeDef,
@@ -99,7 +99,7 @@ class ClusterAddon(EksResource):
     configuration_values: str = ""
     cluster: Cluster = field(default_factory=lambda: Cluster(arn=""))
 
-    def __repr__(self) -> str:
+    def __repr__(self) -> str:  # pragma: no cover
         """Return the string representation of a Cluster Addon."""
         return f"<{self.__class__.__name__} - Name: {self.name} | Version: {self.version} | Last Status: {self.status}>"
 
@@ -177,7 +177,7 @@ class Cluster(EksResource):
     secrets_key_arn: str = ""
     cluster_logging_enabled: bool = False
 
-    def __repr__(self) -> str:
+    def __repr__(self) -> str:  # pragma: no cover
         """Return the string representation of a Cluster."""
         return f"<{self.__class__.__name__} - Name: {self.name} | Version: {self.version} | Last Status: {self.status}>"
 

--- a/eksupgrade/models/eks.py
+++ b/eksupgrade/models/eks.py
@@ -17,7 +17,7 @@ from .base import AwsRegionResource
 
 try:
     from functools import cache
-except ImportError:
+except ImportError:  # pragma: no cover
     from functools import lru_cache as cache
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/eksupgrade/models/eks.py
+++ b/eksupgrade/models/eks.py
@@ -227,7 +227,7 @@ class Cluster(EksResource):
 
     @property
     def cluster_name(self) -> str:
-        """Return the cluster ID."""
+        """Return the cluster name."""
         return self.name
 
     @property

--- a/eksupgrade/models/eks.py
+++ b/eksupgrade/models/eks.py
@@ -49,11 +49,12 @@ def requires_cluster(function):
     """Decorate methods to require a cluster attribute."""
 
     def wrapper(self, *args, **kwargs):
-        if not self.cluster:
+        if not self.cluster.name:
             logger.error(
                 "Unable to use method: %s without the cluster attribute! Pass a cluster to this child object!",
                 function.__name__,
             )
+            return None
         return function(self, *args, **kwargs)
 
     return wrapper

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -530,15 +530,15 @@ def update_addons(cluster_name: str, version: str, vpc_pass: bool, region_name: 
         raise error
 
 
-def is_cluster_auto_scaler_present(cluster_name: str, region: str) -> List[Union[int, str]]:
-    """Determine whether cluster autoscaler is present."""
+def is_cluster_auto_scaler_present(cluster_name: str, region: str) -> List[Union[bool, int]]:
+    """Determine whether or not cluster autoscaler is present."""
     loading_config(cluster_name, region)
     apps_v1_api = client.AppsV1Api()
     res = apps_v1_api.list_deployment_for_all_namespaces()
     for res_i in res.items:
         if res_i.metadata.name == "cluster-autoscaler":
             return [True, res_i.spec.replicas]
-    return [False, "NAN"]
+    return [False, 0]
 
 
 def cluster_auto_enable_disable(cluster_name: str, operation: str, mx_val: int, region: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,3 +36,21 @@ def eks_client(aws_creds, region) -> Generator[Any, None, None]:
     with mock_eks():
         client = boto3.client("eks", region_name=region)
         yield client
+
+
+@pytest.fixture
+def cluster_name() -> str:
+    """Define the EKS cluster name to be used across test mocks."""
+    return "eks-test"
+
+
+@pytest.fixture
+def eks_cluster(eks_client, cluster_name):
+    """Define the EKS cluster to be reused for mocked calls."""
+    eks_client.create_cluster(
+        name=cluster_name,
+        version="1.21",
+        roleArn=f"arn:aws:iam::123456789012:role/{cluster_name}",
+        resourcesVpcConfig={},
+    )
+    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def eks_cluster(eks_client, cluster_name):
     """Define the EKS cluster to be reused for mocked calls."""
     eks_client.create_cluster(
         name=cluster_name,
-        version="1.21",
+        version="1.23",
         roleArn=f"arn:aws:iam::123456789012:role/{cluster_name}",
         resourcesVpcConfig={},
     )

--- a/tests/test_k8s_client.py
+++ b/tests/test_k8s_client.py
@@ -4,24 +4,6 @@ import pytest
 from eksupgrade.src.k8s_client import get_bearer_token, loading_config
 
 
-@pytest.fixture
-def cluster_name() -> str:
-    """Define the EKS cluster name to be used across test mocks."""
-    return "eks-test"
-
-
-@pytest.fixture
-def eks_cluster(eks_client, cluster_name):
-    """Define the EKS cluster to be reused for mocked calls."""
-    eks_client.create_cluster(
-        name=cluster_name,
-        version="1.21",
-        roleArn=f"arn:aws:iam::123456789012:role/{cluster_name}",
-        resourcesVpcConfig={},
-    )
-    yield
-
-
 def test_get_bearer_token(sts_client, eks_cluster, cluster_name, region) -> None:
     """Test the get_bearer_token method."""
     token = get_bearer_token(cluster_id=cluster_name, region=region)

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -1,0 +1,63 @@
+"""Test the base model logic."""
+from eksupgrade.models.base import AwsRegionResource, AwsResource, BaseResource
+
+
+def test_base_resource() -> None:
+    """Test the base resource."""
+    base_resource = BaseResource()
+    base_dict = base_resource.to_dict()
+    assert not base_dict
+    assert isinstance(base_dict, dict)
+    assert len(base_dict.keys()) == 0
+
+
+def test_aws_resource_no_optional() -> None:
+    """Test the AWS resource without optional arguments."""
+    aws_resource = AwsResource(arn="abc")
+    aws_dict = aws_resource.to_dict()
+    assert isinstance(aws_dict, dict)
+    assert aws_dict["arn"] == "abc"
+    assert not aws_dict["resource_id"]
+    assert not aws_dict["tags"]
+    assert len(aws_dict.keys()) == 3
+
+
+def test_aws_resource_optional() -> None:
+    """Test the AWS resource with optional arguments."""
+    aws_resource = AwsResource(arn="abc", resource_id="123", tags={"Name": "123"})
+    aws_dict = aws_resource.to_dict()
+    assert isinstance(aws_dict, dict)
+    assert aws_dict["arn"] == "abc"
+    assert aws_dict["resource_id"] == "123"
+    assert aws_dict["tags"]["Name"] == "123"
+    assert len(aws_dict.keys()) == 3
+
+
+def test_aws_region_resource_no_optional() -> None:
+    """Test the AWS region resource without optional arguments."""
+    aws_region_resource = AwsRegionResource(arn="abc")
+    aws_dict = aws_region_resource.to_dict()
+    assert isinstance(aws_dict, dict)
+    assert aws_dict["arn"] == "abc"
+    assert not aws_dict["resource_id"]
+    assert not aws_dict["tags"]
+    assert not aws_dict["region"]
+    assert len(aws_dict.keys()) == 4
+
+
+def test_aws_region_resource_optional() -> None:
+    """Test the AWS region resource with optional arguments."""
+    aws_region_resource = AwsRegionResource(arn="abc", resource_id="123", tags={"Name": "123"}, region="us-east-1")
+    aws_dict = aws_region_resource.to_dict()
+    assert isinstance(aws_dict, dict)
+    assert aws_dict["arn"] == "abc"
+    assert aws_dict["resource_id"] == "123"
+    assert aws_dict["tags"]["Name"] == "123"
+    assert aws_dict["region"] == "us-east-1"
+    assert len(aws_dict.keys()) == 4
+
+
+def test_sts_client_region(sts_client) -> None:
+    """Test the STS client on AwsResource."""
+    aws_resource = AwsRegionResource(arn="abc", resource_id="123", tags={"Name": "123"}, region="us-east-1")
+    assert aws_resource.sts_client.meta.region_name == "us-east-1"

--- a/tests/test_models_eks.py
+++ b/tests/test_models_eks.py
@@ -11,7 +11,7 @@ def test_cluster_resource(eks_client, eks_cluster, cluster_name, region) -> None
     cluster_dict = cluster_resource.to_dict()
     assert cluster_dict
     assert isinstance(cluster_dict, dict)
-    assert cluster_dict["version"] == "1.21"
+    assert cluster_dict["version"] == "1.23"
     assert len(cluster_dict.keys()) == 15
     assert cluster_resource.name == cluster_resource.cluster_name
 

--- a/tests/test_models_eks.py
+++ b/tests/test_models_eks.py
@@ -1,0 +1,27 @@
+"""Test the EKS model logic."""
+from eksupgrade.models.eks import Cluster, ClusterAddon
+
+
+def test_cluster_resource(eks_client, eks_cluster, cluster_name, region) -> None:
+    """Test the cluster resource."""
+    cluster_resource = Cluster.get_cluster(cluster_name, region)
+    cluster_dict = cluster_resource.to_dict()
+    assert cluster_dict
+    assert isinstance(cluster_dict, dict)
+    assert cluster_dict["version"] == "1.21"
+    assert len(cluster_dict.keys()) == 15
+
+
+def test_cluster_addon_resource(eks_client, eks_cluster, cluster_name, region) -> None:
+    """Test the cluster addon resource."""
+    cluster_resource = Cluster.get_cluster(cluster_name, region)
+    addon_resource = ClusterAddon(
+        arn="abc", name="coredns", cluster=cluster_resource, region=region, owner="amazon", publisher="amazon"
+    )
+    addon_dict = addon_resource.to_dict()
+    assert isinstance(addon_dict, dict)
+    assert addon_dict["arn"] == "abc"
+    assert addon_resource.name == "coredns"
+    assert not addon_dict["resource_id"]
+    assert not addon_dict["tags"]
+    assert len(addon_dict.keys()) == 17

--- a/tests/test_models_eks.py
+++ b/tests/test_models_eks.py
@@ -1,4 +1,7 @@
 """Test the EKS model logic."""
+from kubernetes.client.api.core_v1_api import CoreV1Api
+from kubernetes.client.api_client import ApiClient
+
 from eksupgrade.models.eks import Cluster, ClusterAddon, requires_cluster
 
 
@@ -21,6 +24,13 @@ def test_cluster_resource_eks_client(eks_client, eks_cluster, cluster_name, regi
     assert cluster_resource.eks_client.meta.region_name == "us-east-1"
 
 
+def test_cluster_resource_core_client(eks_client, eks_cluster, cluster_name, region) -> None:
+    """Test the cluster resource."""
+    cluster_resource = Cluster.get_cluster(cluster_name, region)
+    assert isinstance(cluster_resource.core_api_client, CoreV1Api)
+    assert isinstance(cluster_resource.core_api_client.api_client, ApiClient)
+
+
 def test_cluster_addon_resource(eks_client, eks_cluster, cluster_name, region) -> None:
     """Test the cluster addon resource."""
     cluster_resource = Cluster.get_cluster(cluster_name, region)
@@ -37,6 +47,20 @@ def test_cluster_addon_resource(eks_client, eks_cluster, cluster_name, region) -
     assert addon_resource.name == addon_resource.addon_name
     assert not addon_resource._addon_update_kwargs
     assert isinstance(addon_resource._addon_update_kwargs, dict)
+
+
+def test_cluster_addon_resource_update_kwargs(eks_client, eks_cluster, cluster_name, region) -> None:
+    """Test the cluster addon resource."""
+    cluster_resource = Cluster.get_cluster(cluster_name, region)
+    addon_resource = ClusterAddon(
+        arn="abc", name="coredns", cluster=cluster_resource, region=region, owner="amazon", publisher="amazon"
+    )
+    addon_resource.service_account_role_arn = "123"
+    addon_resource.configuration_values = "123"
+    assert addon_resource._addon_update_kwargs
+    assert isinstance(addon_resource._addon_update_kwargs, dict)
+    assert "serviceAccountRoleArn" in addon_resource._addon_update_kwargs.keys()
+    assert "configurationValues" in addon_resource._addon_update_kwargs.keys()
 
 
 def test_cluster_requires_cluster_decorator(eks_client, eks_cluster, cluster_name, region) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,27 @@
+"""Test the util logic."""
+from eksupgrade.utils import get_package_asset, get_package_dict, get_package_yaml
+
+
+def test_get_package_asset() -> None:
+    """Test the get package asset method."""
+    data = get_package_asset("version_dict.json")
+    assert data.startswith("{")
+    assert data.endswith("\n")
+
+
+def test_get_package_asset_nondefault() -> None:
+    """Test the get package asset method."""
+    data = get_package_asset("__init__.py", base_path="")
+    assert "__version__" in data
+
+
+def test_get_package_dict() -> None:
+    """Test the get package dict method."""
+    data = get_package_dict("version_dict.json")
+    assert data["1.26"]["cluster-autoscaler"]
+
+
+def test_get_package_yaml() -> None:
+    """Test the get package yaml method."""
+    data = get_package_yaml("core-dns.yaml")
+    assert "apiVersion" in data.keys()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary


Resolves: #58 
Resolves: #33 

### Changes

This change introduces the new submodule `models` including `models.eks` and `models.base`.  The `base` submodule includes base models relevant to creating reusable models specific to this tool and AWS services.

### User experience

This provides a cleaner API for interacting with resources within the tool both from CLI and programmatically (enabling further automation using this tool and library in the future).

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
