### PR TITLE
fix: Updated checking psp only for versions below 1.25

### DIFF
--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -124,7 +124,7 @@ def get_cluster_version(
                 return
         cmk_key_check(errors, cluster_name, region, cluster_details, report, customer_report)
         security_group_check(errors, cluster_name, region, cluster_details, report, customer_report)
-        if float(update_version) < 1.25:
+        if float(cluster_details["cluster"]["version"]) < 1.25:
             pod_security_policies(errors, cluster_name, region, report, customer_report)
         node_group_details = nodegroup_customami(errors, cluster_name, region, report, customer_report, update_version)
         report["nodegroup_details"] = node_group_details

--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -124,7 +124,8 @@ def get_cluster_version(
                 return
         cmk_key_check(errors, cluster_name, region, cluster_details, report, customer_report)
         security_group_check(errors, cluster_name, region, cluster_details, report, customer_report)
-        pod_security_policies(errors, cluster_name, region, report, customer_report)
+        if float(update_version) < 1.25:
+            pod_security_policies(errors, cluster_name, region, report, customer_report)
         node_group_details = nodegroup_customami(errors, cluster_name, region, report, customer_report, update_version)
         report["nodegroup_details"] = node_group_details
         customer_report["nodegroup_details"] = node_group_details


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary


Resolves: #66

### Changes

Updated the preflight check on gathering pod security policies for upgrade versions above 1.25. The updated Policy API has removed this attribute leading to failures on pre-flight checks.

Tested changes against running a pre-flight check and upgrading the cluster to `1.25`. 

### User experience

No changes to user experience. This should continue to behave as expected for cluster upgrades till 1.25 and from 1.25.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [X] I have performed a self-review of this change
- [X] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
