### PR TITLE
fix: Removed colliding apinames from import

### DIFF
--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -8,7 +8,6 @@ import boto3
 import urllib3
 import yaml
 from kubernetes import client
-
 from kubernetes.client import *
 
 from eksupgrade.utils import get_package_dict

--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -9,11 +9,6 @@ import urllib3
 import yaml
 from kubernetes import client
 
-try:
-    from kubernetes.client import PolicyV1beta1Api as PolicyV1Api
-except ImportError:
-    from kubernetes.client import PolicyV1Api
-
 from kubernetes.client import *
 
 from eksupgrade.utils import get_package_dict
@@ -266,7 +261,7 @@ def pod_security_policies(
     """Check for pod security policies."""
     loading_config(cluster_name, region)
     try:
-        policy_v1_api = PolicyV1Api()
+        policy_v1_api = PolicyV1beta1Api()
         logger.info("Pod Security Policies .....")
         ret = policy_v1_api.list_pod_security_policy(field_selector="metadata.name=eks.privileged")
 
@@ -705,7 +700,7 @@ def pod_disruption_budget(
     loading_config(cluster_name, region)
     logger.info("Fetching Pod Disruption Budget Details....")
     try:
-        policy_v1_api = PolicyV1Api()
+        policy_v1_api = PolicyV1beta1Api()
         ret = policy_v1_api.list_pod_disruption_budget_for_all_namespaces()
         if not ret.items:
             customer_report["pod disruption budget"] = "No Pod Disruption Budget exists in cluster"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary


Resolves: #66 

### Changes

Updated the import in pre-flight module to remove the collision of api names imported resulting in errors for attributes not present.
`from kubernetes.client import *` imports `PolicyV1Api` & `PolicyV1beta1Api`

### User experience

Fixes the issue currently faced with version `0.5.1` onwards.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [X] I have performed a self-review of this change
- [X] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
