### PR TITLE
fix: Check target version and flight type for PDB check

### DIFF
--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -126,7 +126,12 @@ def get_cluster_version(
         subnet_details(errors, cluster_name, region, report, customer_report)
         cluster_roles(preflight, errors, cluster_name, region, report, customer_report)
         addon_version(errors, cluster_name, region, cluster_details, report, customer_report, pass_vpc)
-        pod_disruption_budget(errors, cluster_name, region, report, customer_report, force_upgrade)
+
+        if (float(update_version) == 1.25 and preflight) or float(update_version) < 1.25:
+            pod_disruption_budget(errors, cluster_name, region, report, customer_report, force_upgrade)
+        else:
+            logger.info("Pod Disruption Budget check disabled due to target version: %s", update_version)
+
         horizontal_auto_scaler(errors, cluster_name, region, report, customer_report)
         cluster_auto_scaler(errors, cluster_name, region, report, customer_report)
         # TODO: Revisit deprecation checks. Disabled due to confusing or misleading results per GH Issue #37.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

Resolves: #75

### Changes

> Update legacy CLI pre/post flight validation workflow to only trigger PDB checks when targeting below 1.25 or 1.25 pre-flight.

### User experience

No resulting error due to the PDB check responding with a 404.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
