### PR TITLE
feat: Logger format update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/
 .DS_Store
+.idea
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/eksupgrade/cli.py
+++ b/eksupgrade/cli.py
@@ -80,7 +80,7 @@ Display the eksupgrade version:
     logging.basicConfig(
         level=parsed_arguments.log_level.upper(),
         format="[%(levelname)s] : %(asctime)s : %(name)s : %(message)s",
-        datefmt="%d-%b-%y %H:%M:%S",
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
     main(parsed_arguments)
 

--- a/eksupgrade/cli.py
+++ b/eksupgrade/cli.py
@@ -8,8 +8,9 @@ from typing import List, Optional
 
 from eksupgrade import __version__
 from eksupgrade.starter import main
+from eksupgrade.utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def entry(args: Optional[List[str]] = None) -> None:
@@ -76,7 +77,11 @@ Display the eksupgrade version:
     )
     parser.add_argument("--version", action="version", version=f"eksupgrade {__version__}")
     parsed_arguments = parser.parse_args(args)
-    logging.basicConfig(level=parsed_arguments.log_level.upper())
+    logging.basicConfig(
+        level=parsed_arguments.log_level.upper(),
+        format="[%(levelname)s] : %(asctime)s : %(name)s : %(message)s",
+        datefmt="%d-%b-%y %H:%M:%S",
+    )
     main(parsed_arguments)
 
 

--- a/eksupgrade/models/base.py
+++ b/eksupgrade/models/base.py
@@ -1,7 +1,6 @@
 """Define the base models to be used across the EKS upgrade tool."""
 from __future__ import annotations
 
-import logging
 from abc import ABC
 from dataclasses import dataclass, field
 from functools import cached_property
@@ -20,7 +19,9 @@ else:
     EKSClient = object
     STSClient = object
 
-logger = logging.getLogger(__name__)
+from eksupgrade.utils import get_logger
+
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/eksupgrade/models/eks.py
+++ b/eksupgrade/models/eks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import base64
 import datetime
-import logging
 import re
 import time
 from abc import ABC
@@ -58,7 +57,9 @@ else:
     AutoScalingGroupsTypeTypeDef = object
     AutoScalingGroupTypeDef = object
 
-logger = logging.getLogger(__name__)
+from eksupgrade.utils import get_logger
+
+logger = get_logger(__name__)
 
 TOKEN_PREFIX: str = "k8s-aws-v1"
 TOKEN_HEADER_KEY: str = "x-k8s-aws-id"

--- a/eksupgrade/src/boto_aws.py
+++ b/eksupgrade/src/boto_aws.py
@@ -2,14 +2,15 @@
 from __future__ import annotations
 
 import datetime
-import logging
 import time
 import uuid
 from typing import Any, Dict, List, Optional
 
 import boto3
 
-logger = logging.getLogger(__name__)
+from eksupgrade.utils import get_logger
+
+logger = get_logger(__name__)
 
 
 def status_of_cluster(cluster_name: str, region: str) -> List[str]:

--- a/eksupgrade/src/eks_get_image_type.py
+++ b/eksupgrade/src/eks_get_image_type.py
@@ -1,14 +1,15 @@
 """Define the image type logic for EKS."""
 from __future__ import annotations
 
-import logging
 from typing import Optional
 
 import boto3
 
+from eksupgrade.utils import get_logger
+
 from .k8s_client import find_node
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def image_type(node_type: str, image_id: str, region: str) -> Optional[str]:

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -7,7 +7,6 @@ Attributes:
 from __future__ import annotations
 
 import base64
-import logging
 import queue
 import re
 import threading
@@ -29,9 +28,9 @@ from botocore.signers import RequestSigner
 from kubernetes import client, watch
 from kubernetes.client.rest import ApiException
 
-from eksupgrade.utils import get_package_dict
+from eksupgrade.utils import get_logger, get_package_dict
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 queue = queue.Queue()
 

--- a/eksupgrade/src/latest_ami.py
+++ b/eksupgrade/src/latest_ami.py
@@ -1,11 +1,11 @@
 """Define the AMI specific logic."""
 from __future__ import annotations
 
-import logging
-
 import boto3
 
-logger = logging.getLogger(__name__)
+from eksupgrade.utils import get_logger
+
+logger = get_logger(__name__)
 
 
 def get_latest_ami(cluster_version: str, instance_type: str, image_to_search: str, region: str) -> str:

--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -1,7 +1,6 @@
 """Define the preflight module."""
 from __future__ import annotations
 
-import logging
 from typing import Any, Dict, List
 
 import boto3
@@ -15,7 +14,9 @@ from .k8s_client import get_default_version, loading_config
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-logger = logging.getLogger(__name__)
+from eksupgrade.utils import get_logger
+
+logger = get_logger(__name__)
 
 
 # Function declaration for pre flight checks

--- a/eksupgrade/src/self_managed.py
+++ b/eksupgrade/src/self_managed.py
@@ -1,15 +1,16 @@
 """Define the self-managed node logic."""
 from __future__ import annotations
 
-import logging
 import time
 from typing import Any, Dict, List, Optional
 
 import boto3
 
+from eksupgrade.utils import get_logger
+
 from .latest_ami import get_latest_ami
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def status_of_cluster(cluster_name: str, region: str) -> List[str]:

--- a/eksupgrade/starter.py
+++ b/eksupgrade/starter.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 import datetime
-import logging
 import queue
 import sys
 import threading
 import time
+
+from eksupgrade.utils import get_logger
 
 from .exceptions import ClusterInactiveException
 from .models.eks import Cluster
@@ -33,7 +34,7 @@ from .src.latest_ami import get_latest_ami
 from .src.preflight_module import pre_flight_checks
 from .src.self_managed import update_nodegroup
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 queue = queue.Queue()
 

--- a/eksupgrade/utils.py
+++ b/eksupgrade/utils.py
@@ -1,7 +1,8 @@
 """Define module level utilities to be used across the EKS Upgrade package."""
-
 import json
+import logging
 import pkgutil
+import sys
 
 
 def get_package_asset(filename: str, base_path: str = "src/S3Files/") -> str:
@@ -13,3 +14,16 @@ def get_package_dict(filename: str, base_path: str = "src/S3Files/"):
     """Get the specified package asset data dictionary."""
     _data = get_package_asset(filename, base_path)
     return json.loads(_data)
+
+
+def get_logger(logger_name):
+    """Get a logger object with handler to StreamHandler"""
+    logger = logging.getLogger(logger_name)
+    console_handler = logging.StreamHandler(sys.stdout)
+    log_formatter = logging.Formatter(
+        "[%(levelname)s] : %(asctime)s : %(name)s.%(lineno)d : %(message)s", "%Y-%m-%d %H:%M:%S"
+    )
+    console_handler.setFormatter(log_formatter)
+    logger.addHandler(console_handler)
+    logger.propagate = False
+    return logger

--- a/eksupgrade/utils.py
+++ b/eksupgrade/utils.py
@@ -17,7 +17,7 @@ def get_package_dict(filename: str, base_path: str = "src/S3Files/"):
 
 
 def get_logger(logger_name):
-    """Get a logger object with handler to StreamHandler"""
+    """Get a logger object with handler set to StreamHandler"""
     logger = logging.getLogger(logger_name)
     console_handler = logging.StreamHandler(sys.stdout)
     log_formatter = logging.Formatter(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

Changed the logging format to use timestamp and method line numbers to help with future debugging. Sample log lines below.

```
[INFO] : 2023-03-17 22:00:29 : botocore.credentials : Found credentials in environment variables.
[INFO] : 2023-03-17 22:00:30 : eksupgrade.src.preflight_module.91 : Cluster already upgraded to version 1.22
```


Resolves: #81 

### Changes

- Added `get_logger` method  to utils
- Updated logger object to use the common `get_logger` utility
- Formatted the logs to use log level, date/time and module line numbers.

### User experience

**Before**:

```
INFO:botocore.credentials:Found credentials in environment variables.
INFO:botocore.credentials:Found credentials in environment variables.
INFO:eksupgrade.src.preflight_module:Verifying User IAM Role....
INFO:eksupgrade.src.preflight_module:IAM role for user verified
INFO:botocore.credentials:Found credentials in environment variables.
INFO:eksupgrade.src.preflight_module:Fetching cluster details .....
INFO:eksupgrade.src.preflight_module:Cluster control plane version 1.22
INFO:eksupgrade.src.preflight_module:Cluster already upgraded to version 1.22
```

**After**:
```
[INFO] : 2023-03-17 22:00:29 : botocore.credentials : Found credentials in environment variables.
[INFO] : 2023-03-17 22:00:29 : botocore.credentials : Found credentials in environment variables.
[INFO] : 2023-03-17 22:00:29 : eksupgrade.src.preflight_module.40 : Verifying User IAM Role....
[INFO] : 2023-03-17 22:00:30 : eksupgrade.src.preflight_module.42 : IAM role for user verified
[INFO] : 2023-03-17 22:00:30 : botocore.credentials : Found credentials in environment variables.
[INFO] : 2023-03-17 22:00:30 : eksupgrade.src.preflight_module.79 : Fetching cluster details .....
[INFO] : 2023-03-17 22:00:30 : eksupgrade.src.preflight_module.87 : Cluster control plane version 1.22
[INFO] : 2023-03-17 22:00:30 : eksupgrade.src.preflight_module.91 : Cluster already upgraded to version 1.22
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [X] I have performed a self-review of this change
- [X] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
