### PR TITLE
fix: Modify entry logic to use Typer, colorize output, add interactive prompts

### DIFF
--- a/.github/workflows/e2e-test-template.yaml
+++ b/.github/workflows/e2e-test-template.yaml
@@ -91,22 +91,22 @@ jobs:
         id: no_upgrade
         run: |
           echo "Test the cluster eksup-cluster-${{inputs.cluster_suffix}} with upgrade set to current version"
-          eksupgrade eksup-cluster-${{inputs.cluster_suffix}} ${{inputs.current_version}} us-east-1
+          eksupgrade eksup-cluster-${{inputs.cluster_suffix}} ${{inputs.current_version}} us-east-1 --no-interactive
       - name: Test pre-flight checks
         id: preflight_checks
         run: |
           echo "Running pre-flight checks on the cluster eksup-cluster-${{inputs.cluster_suffix}} against version ${{inputs.target_version}} "
-          eksupgrade eksup-cluster-${{inputs.cluster_suffix}} ${{inputs.target_version}} us-east-1 --preflight
+          eksupgrade eksup-cluster-${{inputs.cluster_suffix}} ${{inputs.target_version}} us-east-1 --preflight --no-interactive
       - name: Test standalone addon upgrade
         id: addon_upgrade
         run: |
           echo "Running upgrade addon checks on the cluster eksup-cluster-${{inputs.cluster_suffix}} with same control plane version "
-          eksupgrade eksup-cluster-${{inputs.cluster_suffix}} ${{inputs.current_version}} us-east-1 --latest-addons
+          eksupgrade eksup-cluster-${{inputs.cluster_suffix}} ${{inputs.current_version}} us-east-1 --latest-addons --no-interactive
       - name: Test cluster upgrade
         id: cluster_upgrade
         run: |
           echo "Upgrading the cluster eksup-cluster-${{inputs.cluster_suffix}} to version ${{inputs.target_version}} "
-          eksupgrade eksup-cluster-${{inputs.cluster_suffix}} ${{inputs.target_version}} us-east-1
+          eksupgrade eksup-cluster-${{inputs.cluster_suffix}} ${{inputs.target_version}} us-east-1 --no-interactive
       - name: Destroy the cluster
         if: ${{inputs.trigger_destroy == 'true'}}
         uses: './.github/actions/delete-cluster'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There are a number of version compatibility constraints, health checks, etc., be
 5. Subnets - A minimum of 4-5 free IPs are required when doing a cluster upgrade to launch new nodes and node groups with the old ones to keep the services of the cluster running while the upgrade is going on. So check on the existence of the free IPs is performed.
 6. Cluster Roles - There are a lot of important cluster roles required during the upgrade related to addons, nodes, and other components of the cluster without which the cluster upgrade cannot be executed successfully.
 7. Pod Security Policy - EKS privileged role has to be checked to be present with the current pod security policy. (deprecated in Kubernetes v1.21, and removed from Kubernetes in v1.25)
-8. Cluster addons - The cluster addons like kube-proxy, VPC CNI and CoreDNS are essential for running various services across the cluster. The parameters available on these addons which are customized by the users on the target cluster have to be captured while upgrading so that they are to added back to maintain service availability. 
+8. Cluster addons - The cluster addons like kube-proxy, VPC CNI and CoreDNS are essential for running various services across the cluster. The parameters available on these addons which are customized by the users on the target cluster have to be captured while upgrading so that they are to added back to maintain service availability.
 9. Pod Disruption Budget - The existence of PDB has to be checked in the cluster, and minimum and maximum available with it has to be taken into account while upgrading.
 10. Horizontal Pod and Cluster Autoscaler - As the other components are upgraded to the compatible image version, a check is performed to see if Cluster or Horizontal Pod Autoscaler are present. They are reviewed to upgrade to a compatible version with respect to the control plane.
 
@@ -114,7 +114,7 @@ eksupgrade --help
 ```
 
 ```sh
-usage: eksupgrade [-h] [--pass_vpc] [--max_retry MAX_RETRY] [--force]
+usage: eksupgrade [-h] [--max_retry MAX_RETRY] [--force]
                   [--preflight] [--disable-checks] [--parallel]
                   [--latest-addons] [--log-level LOG_LEVEL] [--version]
                   name version region
@@ -128,7 +128,6 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  --pass_vpc            this --pass-vpc will skip the vpc cni upgrade
   --max_retry MAX_RETRY
                         you can specify max retry or else by default it is 2
   --force               force pod eviction when you have pdb
@@ -150,10 +149,6 @@ example:
 Force pod eviction when you have PDB (Pod Disruption Budget):
 
   eksupgrade <name> <version> <region>n --force
-
-Skip VPC CNI upgrade:
-
-  eksupgrade <name> <version> <region> --pass_vpc
 
 Skip upgrade workflow:
 

--- a/README.md
+++ b/README.md
@@ -115,30 +115,28 @@ eksupgrade --help
 ```
 
 ```sh
- Usage: eksupgrade [OPTIONS] CLUSTER_NAME CLUSTER_VERSION REGION [MAX_RETRY]
-                   [LOG_LEVEL]
+ Usage: eksupgrade [OPTIONS] CLUSTER_NAME CLUSTER_VERSION REGION
 
  Run eksupgrade against a target cluster.
 
 ╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ *    cluster_name         TEXT         The name of the cluster to be upgraded [default: None] [required]                                                                                                            │
-│ *    cluster_version      TEXT         The target Kubernetes version to upgrade the cluster to [default: None] [required]                                                                                           │
-│ *    region               TEXT         The AWS region where the target cluster resides [default: None] [required]                                                                                                   │
-│      max_retry            [MAX_RETRY]  The most number of times to retry an upgrade [default: 2]                                                                                                                    │
-│      log_level            [LOG_LEVEL]  The log level to be displayed in the console [default: INFO]                                                                                                                 │
+│ *    cluster_name         TEXT  The name of the cluster to be upgraded [default: None] [required]                                                                                                                   │
+│ *    cluster_version      TEXT  The target Kubernetes version to upgrade the cluster to [default: None] [required]                                                                                                  │
+│ *    region               TEXT  The AWS region where the target cluster resides [default: None] [required]                                                                                                          │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --force                 --no-force               Force the upgrade (e.g. pod eviction with PDB) [default: no-force]                                                                                                 │
-│ --preflight             --no-preflight           Run pre-flight check without upgrade [default: no-preflight]                                                                                                       │
-│ --parallel              --no-parallel            Upgrade all nodegroups in parallel [default: no-parallel]                                                                                                          │
-│ --latest-addons         --no-latest-addons       Upgrade addons to the latest eligible version instead of default [default: no-latest-addons]                                                                       │
-│ --disable-checks        --no-disable-checks      Disable the pre-flight and post-flight checks during upgrade scenarios [default: no-disable-checks]                                                                │
-│ --interactive           --no-interactive         If enabled, prompt the user for confirmations [default: interactive]                                                                                               │
-│ --version                                        Display the current eksupgrade version                                                                                                                             │
-│ --install-completion                             Install completion for the current shell.                                                                                                                          │
-│ --show-completion                                Show completion for the current shell, to copy it or customize the installation.                                                                                   │
-│ --help                                           Show this message and exit.                                                                                                                                        │
-╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ --max-retry                                    INTEGER  The most number of times to retry an upgrade [default: 2]                                                                                                   │
+│ --force                 --no-force                      Force the upgrade (e.g. pod eviction with PDB) [default: no-force]                                                                                          │
+│ --preflight             --no-preflight                  Run pre-flight check without upgrade [default: no-preflight]                                                                                                │
+│ --parallel              --no-parallel                   Upgrade all nodegroups in parallel [default: no-parallel]                                                                                                   │
+│ --latest-addons         --no-latest-addons              Upgrade addons to the latest eligible version instead of default [default: no-latest-addons]                                                                │
+│ --disable-checks        --no-disable-checks             Disable the pre-flight and post-flight checks during upgrade scenarios [default: no-disable-checks]                                                         │
+│ --interactive           --no-interactive                If enabled, prompt the user for confirmations [default: interactive]                                                                                        │
+│ --version                                               Display the current eksupgrade version                                                                                                                      │
+│ --install-completion                                    Install completion for the current shell.                                                                                                                   │
+│ --show-completion                                       Show completion for the current shell, to copy it or customize the installation.                                                                            │
+│ --help                                                  Show this message and exit.                                                                                                                                 │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -115,53 +115,30 @@ eksupgrade --help
 ```
 
 ```sh
-usage: eksupgrade [-h] [--max_retry MAX_RETRY] [--force]
-                  [--preflight] [--disable-checks] [--parallel]
-                  [--latest-addons] [--log-level LOG_LEVEL] [--version]
-                  name version region
+ Usage: eksupgrade [OPTIONS] CLUSTER_NAME CLUSTER_VERSION REGION [MAX_RETRY]
+                   [LOG_LEVEL]
 
-Amazon EKS cluster upgrade
+ Run eksupgrade against a target cluster.
 
-positional arguments:
-  name                  Cluster Name
-  version               new version which you want to update
-  region                The AWS region where the cluster resides
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --max_retry MAX_RETRY
-                        you can specify max retry or else by default it is 2
-  --force               force pod eviction when you have pdb
-  --preflight           Run pre-flight check without upgrade
-  --disable-checks      Totally disable the pre-flight and post-flight
-                        checks during upgrade scenarios
-  --parallel            Upgrade all nodegroups in parallel
-  --latest-addons       Upgrade addons to the latest eligible version
-                        instead of default
-  --log-level LOG_LEVEL
-                        The log level to be displayed in the console.
-                        Default to: INFO
-  --version             show program's version number and exit
-
-example:
-
-  eksupgrade <name> <version> <region>
-
-Force pod eviction when you have PDB (Pod Disruption Budget):
-
-  eksupgrade <name> <version> <region>n --force
-
-Skip upgrade workflow:
-
-  eksupgrade <name> <version> <region> --preflight
-
-Set log level to console (default to INFO):
-
-  eksupgrade <name> <version> <region> --log-level debug
-
-Display the eksupgrade version:
-
-  eksupgrade --version
+╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ *    cluster_name         TEXT         The name of the cluster to be upgraded [default: None] [required]                                                                                                            │
+│ *    cluster_version      TEXT         The target Kubernetes version to upgrade the cluster to [default: None] [required]                                                                                           │
+│ *    region               TEXT         The AWS region where the target cluster resides [default: None] [required]                                                                                                   │
+│      max_retry            [MAX_RETRY]  The most number of times to retry an upgrade [default: 2]                                                                                                                    │
+│      log_level            [LOG_LEVEL]  The log level to be displayed in the console [default: INFO]                                                                                                                 │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --force                 --no-force               Force the upgrade (e.g. pod eviction with PDB) [default: no-force]                                                                                                 │
+│ --preflight             --no-preflight           Run pre-flight check without upgrade [default: no-preflight]                                                                                                       │
+│ --parallel              --no-parallel            Upgrade all nodegroups in parallel [default: no-parallel]                                                                                                          │
+│ --latest-addons         --no-latest-addons       Upgrade addons to the latest eligible version instead of default [default: no-latest-addons]                                                                       │
+│ --disable-checks        --no-disable-checks      Disable the pre-flight and post-flight checks during upgrade scenarios [default: no-disable-checks]                                                                │
+│ --interactive           --no-interactive         If enabled, prompt the user for confirmations [default: interactive]                                                                                               │
+│ --version                                        Display the current eksupgrade version                                                                                                                             │
+│ --install-completion                             Install completion for the current shell.                                                                                                                          │
+│ --show-completion                                Show completion for the current shell, to copy it or customize the installation.                                                                                   │
+│ --help                                           Show this message and exit.                                                                                                                                        │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ```
 
 ## Security

--- a/eksupgrade/__main__.py
+++ b/eksupgrade/__main__.py
@@ -1,0 +1,4 @@
+"""Handle the main entry logic."""
+from .cli import app
+
+app(prog_name="eksupgrade")

--- a/eksupgrade/cli.py
+++ b/eksupgrade/cli.py
@@ -36,14 +36,13 @@ def main(
     cluster_name: str = typer.Argument(..., help="The name of the cluster to be upgraded"),
     cluster_version: str = typer.Argument(..., help="The target Kubernetes version to upgrade the cluster to"),
     region: str = typer.Argument(..., help="The AWS region where the target cluster resides"),
-    max_retry: int = typer.Argument(default=2, help="The most number of times to retry an upgrade"),
+    max_retry: int = typer.Option(default=2, help="The most number of times to retry an upgrade"),
     force: bool = typer.Option(default=False, help="Force the upgrade (e.g. pod eviction with PDB)"),
     preflight: bool = typer.Option(default=False, help="Run pre-flight check without upgrade"),
     parallel: bool = typer.Option(default=False, help="Upgrade all nodegroups in parallel"),
     latest_addons: bool = typer.Option(
         default=False, help="Upgrade addons to the latest eligible version instead of default"
     ),
-    log_level: str = typer.Argument(default="INFO", help="The log level to be displayed in the console"),
     disable_checks: bool = typer.Option(
         default=False, help="Disable the pre-flight and post-flight checks during upgrade scenarios"
     ),

--- a/eksupgrade/cli.py
+++ b/eksupgrade/cli.py
@@ -53,12 +53,6 @@ def main(
     ),
 ) -> None:
     """Run eksupgrade against a target cluster."""
-    logging.basicConfig(
-        level=log_level.upper(),
-        format="[%(levelname)s] : %(asctime)s : %(name)s : %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-
     queue = Queue()
     is_present: bool = False
     replicas_value: int = 0

--- a/eksupgrade/cli.py
+++ b/eksupgrade/cli.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from rich.table import Table
 
 from eksupgrade import __version__
-from eksupgrade.utils import echo_error, echo_info, echo_success, echo_warning, get_logger, interactive_confirm
+from eksupgrade.utils import confirm, echo_error, echo_info, echo_success, echo_warning, get_logger
 
 from .exceptions import ClusterInactiveException
 from .models.eks import Cluster
@@ -89,10 +89,10 @@ def main(
         )
 
         # Confirm whether or not to proceed following pre-flight checks.
-        interactive_confirm(
-            f"Are you sure you want to proceed with the upgrade process against: {cluster_name}?",
-            interactive,
-        )
+        if interactive:
+            confirm(
+                f"Are you sure you want to proceed with the upgrade process against: {cluster_name}?",
+            )
 
         if not target_cluster.available:
             echo_error("The cluster is not active!")
@@ -181,6 +181,8 @@ def main(
                 echo_success("After update check for cluster completed successfully")
         else:
             echo_warning("Post-flight check was disabled and didn't run.")
+    except typer.Abort:
+        echo_warning("Cluster upgrade aborted!")
     except Exception as error:
         if is_present:
             try:

--- a/eksupgrade/cli.py
+++ b/eksupgrade/cli.py
@@ -52,24 +52,7 @@ def main(
         None, "--version", callback=version_callback, is_eager=True, help="Display the current eksupgrade version"
     ),
 ) -> None:
-    """Run eksupgrade against a target cluster.
-
-    example:
-        eksupgrade <cluster_name> <cluster_version> <region>
-
-    Force pod eviction when you have PDB (Pod Disruption Budget):
-        eksupgrade <name> <version> <region> --force
-
-    Skip upgrade workflow:
-        eksupgrade <name> <version> <region> --preflight
-
-    Set log level to console (default to INFO):
-        eksupgrade <name> <version> <region> --log-level debug
-
-    Display the eksupgrade version:
-        eksupgrade --version
-
-    """
+    """Run eksupgrade against a target cluster."""
     logging.basicConfig(
         level=log_level.upper(),
         format="[%(levelname)s] : %(asctime)s : %(name)s : %(message)s",

--- a/eksupgrade/cli.py
+++ b/eksupgrade/cli.py
@@ -1,89 +1,222 @@
 """Handle CLI specific logic and module definitions."""
 from __future__ import annotations
 
-import argparse
 import logging
 import sys
-from typing import List, Optional
+from queue import Queue
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
 
 from eksupgrade import __version__
-from eksupgrade.starter import main
-from eksupgrade.utils import get_logger
+from eksupgrade.utils import echo_error, echo_info, echo_success, echo_warning, get_logger, interactive_confirm
+
+from .exceptions import ClusterInactiveException
+from .models.eks import Cluster
+from .src.k8s_client import cluster_auto_enable_disable, is_cluster_auto_scaler_present
+from .src.preflight_module import pre_flight_checks
+from .starter import StatsWorker, actual_update
 
 logger = get_logger(__name__)
+app = typer.Typer(help="Automated Amazon EKS cluster upgrade CLI utility")
+console = Console()
 
 
-def entry(args: Optional[List[str]] = None) -> None:
-    """Handle the CLI entrypoint argument parsing."""
-    # If no arguments are provided directly to the function, default to input.
-    if not args:
-        args = sys.argv[1:]
+def version_callback(value: bool) -> None:
+    """Handle the version callback."""
+    if value:
+        typer.secho(f"eksupgrade version: {__version__}", fg=typer.colors.BRIGHT_BLUE, bold=True)
+        raise typer.Exit()
 
-    example_text = """
-example:
 
-  eksupgrade <name> <version> <region>
+@app.command()
+def main(
+    cluster_name: str = typer.Argument(..., help="The name of the cluster to be upgraded"),
+    cluster_version: str = typer.Argument(..., help="The target Kubernetes version to upgrade the cluster to"),
+    region: str = typer.Argument(..., help="The AWS region where the target cluster resides"),
+    max_retry: int = typer.Argument(default=2, help="The most number of times to retry an upgrade"),
+    force: bool = typer.Option(default=False, help="Force the upgrade (e.g. pod eviction with PDB)"),
+    preflight: bool = typer.Option(default=False, help="Run pre-flight check without upgrade"),
+    parallel: bool = typer.Option(default=False, help="Upgrade all nodegroups in parallel"),
+    latest_addons: bool = typer.Option(
+        default=False, help="Upgrade addons to the latest eligible version instead of default"
+    ),
+    log_level: str = typer.Argument(default="INFO", help="The log level to be displayed in the console"),
+    disable_checks: bool = typer.Option(
+        default=False, help="Disable the pre-flight and post-flight checks during upgrade scenarios"
+    ),
+    interactive: bool = typer.Option(default=True, help="If enabled, prompt the user for confirmations"),
+    version: Optional[bool] = typer.Option(
+        None, "--version", callback=version_callback, is_eager=True, help="Display the current eksupgrade version"
+    ),
+) -> None:
+    """Run eksupgrade against a target cluster.
 
-Force pod eviction when you have PDB (Pod Disruption Budget):
+    example:
+        eksupgrade <cluster_name> <cluster_version> <region>
 
-  eksupgrade <name> <version> <region>n --force
+    Force pod eviction when you have PDB (Pod Disruption Budget):
+        eksupgrade <name> <version> <region> --force
 
-Skip VPC CNI upgrade:
+    Skip upgrade workflow:
+        eksupgrade <name> <version> <region> --preflight
 
-  eksupgrade <name> <version> <region> --pass_vpc
+    Set log level to console (default to INFO):
+        eksupgrade <name> <version> <region> --log-level debug
 
-Skip upgrade workflow:
+    Display the eksupgrade version:
+        eksupgrade --version
 
-  eksupgrade <name> <version> <region> --preflight
-
-Set log level to console (default to INFO):
-
-  eksupgrade <name> <version> <region> --log-level debug
-
-Display the eksupgrade version:
-
-  eksupgrade --version
-"""
-
-    parser = argparse.ArgumentParser(
-        description="Amazon EKS cluster upgrade",
-        epilog=example_text,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument("name", help="Cluster Name")
-    parser.add_argument("version", help="new version which you want to update")
-    parser.add_argument("region", help="The AWS region where the cluster resides")
-    parser.add_argument(
-        "--pass_vpc", action="store_true", default=False, help="this --pass-vpc will skip the vpc cni upgrade"
-    )
-    parser.add_argument("--max_retry", default=2, type=int, help="you can specify max retry or else by default it is 2")
-    parser.add_argument("--force", action="store_true", default=False, help="force pod eviction when you have pdb")
-    parser.add_argument("--preflight", action="store_true", default=False, help="Run pre-flight check without upgrade")
-    parser.add_argument(
-        "--disable-checks",
-        action="store_true",
-        default=False,
-        help="Disable pre-flight and post-flight checks",
-    )
-    parser.add_argument("--parallel", action="store_true", default=False, help="Upgrade all nodegroups in parallel")
-    parser.add_argument(
-        "--latest-addons",
-        action="store_true",
-        default=False,
-        help="Upgrade addons to the latest eligible version instead of their default version",
-    )
-    parser.add_argument(
-        "--log-level", default="INFO", help="The log level to be displayed in the console. Default to: INFO"
-    )
-    parser.add_argument("--version", action="version", version=f"eksupgrade {__version__}")
-    parsed_arguments = parser.parse_args(args)
+    """
     logging.basicConfig(
-        level=parsed_arguments.log_level.upper(),
+        level=log_level.upper(),
         format="[%(levelname)s] : %(asctime)s : %(name)s : %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
-    main(parsed_arguments)
+
+    queue = Queue()
+    is_present: bool = False
+    replicas_value: int = 0
+
+    try:
+        # Preflight Logic
+        if not disable_checks:
+            if not pre_flight_checks(
+                preflight=True,
+                cluster_name=cluster_name,
+                region=region,
+                update_version=cluster_version,
+                force_upgrade=force,
+            ):
+                echo_error(
+                    f"Pre-flight check for cluster {cluster_name} targeting version: {cluster_version} failed!",
+                )
+                sys.exit()
+            else:
+                echo_success(
+                    f"Pre-flight check for the cluster {cluster_name} succeeded!",
+                )
+            if preflight:
+                sys.exit()
+        else:
+            echo_warning("Checks disabled! Pre/post-flight checks not executing!")
+
+        # Pull cluster details, populating the object for subsequent use throughout the upgrade.
+        target_cluster: Cluster = Cluster.get(
+            cluster_name=cluster_name, region=region, target_version=cluster_version, latest_addons=latest_addons
+        )
+        echo_info(
+            f"Upgrading cluster: {cluster_name} from version: {target_cluster.version} to {target_cluster.target_version}...",
+        )
+
+        # Confirm whether or not to proceed following pre-flight checks.
+        interactive_confirm(
+            f"Are you sure you want to proceed with the upgrade process against: {cluster_name}?",
+            interactive,
+        )
+
+        if not target_cluster.available:
+            echo_error("The cluster is not active!")
+            raise ClusterInactiveException("The cluster is not active")
+
+        echo_info(
+            f"The current version of the cluster was detected as: {target_cluster.version}",
+        )
+
+        # Checking Cluster is Active or Not Before Making an Update
+        if target_cluster.active:
+            target_cluster.update_cluster(wait=True)
+        else:
+            echo_warning(
+                f"The target EKS cluster: {target_cluster.name} isn't currently active - status: {target_cluster.status}",
+            )
+            target_cluster.wait_for_active()
+
+        echo_info("Found the following Managed Nodegroups")
+        for _mng_nodegroup_name in target_cluster.nodegroup_names:
+            echo_info(f"\t* {_mng_nodegroup_name}")
+
+        managed_nodegroup_asgs: list[str] = []
+        for nodegroup in target_cluster.nodegroups:
+            managed_nodegroup_asgs += nodegroup.autoscaling_group_names
+
+        # removing self-managed from managed so that we don't update them again
+        asg_list_self_managed = list(set(target_cluster.asg_names) - set(managed_nodegroup_asgs))
+
+        # addons update
+        target_cluster.upgrade_addons(wait=True)
+
+        # checking auto scaler present and the value associated from it
+        is_present, replicas_value = is_cluster_auto_scaler_present(cluster_name=cluster_name, region=region)
+
+        if is_present:
+            cluster_auto_enable_disable(
+                cluster_name=cluster_name, operation="pause", mx_val=replicas_value, region=region
+            )
+            echo_info("Paused the Cluster AutoScaler")
+        else:
+            echo_info("No Cluster AutoScaler is Found")
+
+        if parallel:
+            for x in range(20):
+                worker = StatsWorker(queue, x)
+                worker.setDaemon(True)
+                worker.start()
+
+        if target_cluster.upgradable_managed_nodegroups:
+            _mng_nodegroup_table = Table("Name", "Version")
+            for item in target_cluster.upgradable_managed_nodegroups:
+                _mng_nodegroup_table.add_row(item.name, item.version)
+            echo_info("Outdated managed nodegroups:")
+            console.print(_mng_nodegroup_table)
+        else:
+            echo_warning("No outdated managed nodegroups found!")
+
+        target_cluster.upgrade_nodegroups(wait=not parallel)
+
+        # TODO: Use custom_ami to update launch templates and re-roll self-managed nodes under ASGs.
+        echo_info("Found the following Self-managed Nodegroups:")
+        for asg_iter in asg_list_self_managed:
+            echo_info(f"\t* {asg_iter}")
+            if parallel:
+                queue.put([cluster_name, asg_iter, cluster_version, region, max_retry, force, "selfmanaged"])
+            else:
+                actual_update(cluster_name, asg_iter, cluster_version, region, max_retry, force)
+
+        if parallel:
+            queue.join()
+
+        if is_present:
+            cluster_auto_enable_disable(
+                cluster_name=cluster_name, operation="start", mx_val=replicas_value, region=region
+            )
+            echo_info("Cluster Autoscaler is Enabled Again")
+        echo_info(f"EKS Cluster {cluster_name} UPDATED TO {cluster_version}")
+
+        if not disable_checks:
+            if not pre_flight_checks(preflight=False, cluster_name=cluster_name, region=region, force_upgrade=force):
+                echo_error(
+                    f"Post flight check for cluster {cluster_name} failed after it upgraded",
+                )
+            else:
+                echo_success("After update check for cluster completed successfully")
+        else:
+            echo_warning("Post-flight check was disabled and didn't run.")
+    except Exception as error:
+        if is_present:
+            try:
+                cluster_auto_enable_disable(
+                    cluster_name=cluster_name, operation="start", mx_val=replicas_value, region=region
+                )
+                echo_info("Cluster Autoscaler is Enabled Again")
+            except Exception as error2:
+                echo_error(
+                    f"Autoenable failed and must be done manually! Error: {error2}",
+                )
+        echo_error(f"Exception encountered! Error: {error}")
 
 
 if __name__ == "__main__":  # pragma: no cover
-    entry()
+    app(prog_name="eksupgrade")

--- a/eksupgrade/models/base.py
+++ b/eksupgrade/models/base.py
@@ -19,7 +19,7 @@ else:
     EKSClient = object
     STSClient = object
 
-from eksupgrade.utils import get_logger
+from eksupgrade.utils import echo_info, echo_success, get_logger
 
 logger = get_logger(__name__)
 
@@ -48,8 +48,9 @@ class BaseResource(ABC):
         _cached_properties: List[str] = get_cached_properties(cached_property)
 
         for _cached_property in _cached_properties:
-            logger.info("%s: Clearing cached property: %s", self.__class__.__name__, _cached_property)
+            echo_info(f"{self.__class__.__name__}: Clearing cached property: {_cached_property}")
             delattr(self, _cached_property)
+        echo_success("Cached properties cleared!")
 
 
 @dataclass

--- a/eksupgrade/src/eks_get_image_type.py
+++ b/eksupgrade/src/eks_get_image_type.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import boto3
 
-from eksupgrade.utils import get_logger
+from eksupgrade.utils import echo_error, echo_warning, get_logger
 
 from .k8s_client import find_node
 
@@ -42,7 +42,7 @@ def image_type(node_type: str, image_id: str, region: str) -> Optional[str]:
             {"Name": "is-public", "Values": ["true"]},
         ]
     else:
-        logger.info("Node type: %s is unsupported  - Image ID: %s", node_type, image_id)
+        echo_warning(f"Node type: {node_type} is unsupported  - Image ID: {image_id}")
         return None
 
     # describing image types
@@ -64,7 +64,7 @@ def get_ami_name(cluster_name: str, asg_name: str, region: str):
     response = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
     instance_ids = [instance["InstanceId"] for instance in response["AutoScalingGroups"][0]["Instances"]]
     if not instance_ids:
-        logger.error("No instances found to determine AMI - cluster: %s - ASG: %s", cluster_name, asg_name)
+        echo_error(f"No instances found to determine AMI - cluster: {cluster_name} - ASG: {asg_name}")
         raise Exception("No Instances")
 
     response = ec2_client.describe_instances(InstanceIds=instance_ids)

--- a/eksupgrade/src/latest_ami.py
+++ b/eksupgrade/src/latest_ami.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import boto3
 
-from eksupgrade.utils import get_logger
+from eksupgrade.utils import echo_error, get_logger
 
 logger = get_logger(__name__)
 
@@ -35,5 +35,5 @@ def get_latest_ami(cluster_version: str, instance_type: str, image_to_search: st
     response = ssm.get_parameters(Names=names)
     if response.get("Parameters"):
         return response.get("Parameters")[0]["Value"]
-    logger.error("Couldn't find the latest image - please retry the script!")
+    echo_error("Couldn't find the latest image - please retry the script!")
     raise Exception("Couldn't Find Latest Image Retry The Script")

--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -331,7 +331,6 @@ def addon_version(
                     "env": daemon_set_item.spec.template.spec.containers[0].env,
                 }
                 version = version_str.split(".")
-                echo_info(f"VPC CNI found version: {version} - version_str: {version_str}")
                 echo_info(f"Likely desired vpc-cni version: {cni_target_version}")
                 check_pods_running("aws-node", report, errors)
                 if int("".join(version)) >= 170:

--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -8,7 +8,7 @@ import urllib3
 import yaml
 from kubernetes import client
 
-from eksupgrade.utils import get_package_dict
+from eksupgrade.utils import echo_error, echo_info, echo_success, echo_warning, get_package_dict
 
 from .k8s_client import get_default_version, loading_config
 
@@ -25,11 +25,11 @@ def pre_flight_checks(
     preflight,
     cluster_name: str,
     region: str,
-    pass_vpc: bool,
-    update_version: bool = False,
+    update_version: str = "",
     force_upgrade: bool = False,
 ) -> bool:
     """Handle the pre-flight checks."""
+    echo_info(f"Running validation checks against cluster: {cluster_name}...")
     loading_config(cluster_name, region)
     report: Dict[str, Any] = {"preflight_status": True}
     customer_report: Dict[str, Any] = {}
@@ -37,15 +37,14 @@ def pre_flight_checks(
     errors: List[str] = []
     try:
         core_v1_api = client.CoreV1Api()
-        logger.info("Verifying User IAM Role....")
+        echo_info("Verifying User IAM Role...")
         core_v1_api.list_namespaced_service("default")
-        logger.info("IAM role for user verified")
+        echo_info("IAM role for user verified!")
         customer_report["IAM role"] = "IAM role for user verified"
         get_cluster_version(
             errors,
             cluster_name,
             region,
-            pass_vpc,
             update_version,
             report,
             customer_report,
@@ -53,11 +52,11 @@ def pre_flight_checks(
         )
 
         if errors:
-            logger.error(
-                "%s flight unsuccessful because of the following errors: %s", "Pre" if preflight else "Post", errors
+            echo_error(
+                f"{'Pre' if preflight else 'Post'} flight unsuccessful because of the following errors: {errors}",
             )
     except Exception as error:
-        logger.error("IAM role verification failed - Error: %s", error)
+        echo_error(f"IAM role verification failed - Error: {error}")
         report["preflight_status"] = False
         customer_report["IAM role"] = "IAM role verification failed"
     return report["preflight_status"]
@@ -68,7 +67,6 @@ def get_cluster_version(
     errors,
     cluster_name,
     region,
-    pass_vpc,
     update_version,
     report,
     customer_report,
@@ -76,7 +74,7 @@ def get_cluster_version(
 ) -> None:
     """Determine the cluster version."""
     loading_config(cluster_name, region)
-    logger.info("Fetching cluster details .....")
+    echo_info("Fetching cluster details...")
     eks = boto3.client("eks", region_name=region)
     try:
         cluster_details = eks.describe_cluster(name=cluster_name)
@@ -84,19 +82,17 @@ def get_cluster_version(
             "version": cluster_details["cluster"]["version"],
             "region": cluster_details["cluster"]["arn"].split(":")[3],
         }
-        logger.info("Cluster control plane version %s", report["cluster"]["version"])
+        echo_info(f"Cluster control plane version {report['cluster']['version']}")
         customer_report["cluster version"] = "Cluster control plane version " + report["cluster"]["version"]
         if update_version:
             if cluster_details["cluster"]["version"] == update_version:
-                logger.info("Cluster already upgraded to version %s", cluster_details["cluster"]["version"])
+                echo_warning(f"Cluster already upgraded to version {cluster_details['cluster']['version']}")
                 customer_report["cluster upgradation"] = (
                     "Cluster already upgraded to version " + cluster_details["cluster"]["version"]
                 )
             elif (round(float(update_version) - float(cluster_details["cluster"]["version"]), 2)) == 0.01:
-                logger.info(
-                    "Cluster with version %s can be updated to target version %s",
-                    cluster_details["cluster"]["version"],
-                    update_version,
+                echo_info(
+                    f"Cluster with version {cluster_details['cluster']['version']} can be updated to target version {update_version}",
                 )
                 customer_report[
                     "cluster upgradation"
@@ -105,10 +101,8 @@ def get_cluster_version(
                 customer_report[
                     "cluster upgradation"
                 ] = f"Cluster with version {cluster_details['cluster']['version']} cannot be updated to target version {update_version}"
-                logger.info(
-                    "Cluster with version %s cannot be updated to target version %s",
-                    cluster_details["cluster"]["version"],
-                    update_version,
+                echo_error(
+                    f"Cluster with version {cluster_details['cluster']['version']} cannot be updated to target version {update_version}",
                 )
                 report["preflight_status"] = False
                 errors.append(
@@ -124,7 +118,7 @@ def get_cluster_version(
         customer_report["nodegroup_details"] = node_group_details
         subnet_details(errors, cluster_name, region, report, customer_report)
         cluster_roles(errors, cluster_name, region, report, customer_report)
-        addon_version(errors, cluster_name, region, cluster_details, report, customer_report, pass_vpc)
+        addon_version(errors, cluster_name, region, cluster_details, report, customer_report)
         pod_disruption_budget(errors, cluster_name, region, report, customer_report, force_upgrade)
         horizontal_auto_scaler(errors, cluster_name, region, report, customer_report)
         cluster_auto_scaler(errors, cluster_name, region, report, customer_report)
@@ -132,7 +126,7 @@ def get_cluster_version(
     except Exception as error:
         errors.append(f"Some error occurred during preflight check process {error}")
         customer_report["cluster version"] = "Some error occured during preflight check process"
-        logger.error("Some error occurred during preflight check process - Error: %s", error)
+        echo_error(f"Some error occurred during preflight check process - Error: {error}")
         report["preflight_status"] = False
 
 
@@ -143,7 +137,7 @@ def subnet_details(
     """Get subnet details."""
     loading_config(cluster_name, region)
     try:
-        logger.info("Checking Available IP for subnets associated with cluster.....")
+        echo_info("Checking Available IP for subnets associated with cluster...")
         eks = boto3.client("eks", region_name=region)
         cluster_details = eks.describe_cluster(name=cluster_name)
         subnets: List[Dict[str, Any]] = []
@@ -158,25 +152,25 @@ def subnet_details(
                 encountered_errors.append(f"Subnet ID {subnet_id} doesnt have a minimum of 5 available IP")
 
             customer_report["subnet"].append(
-                f"Subnet ID {subnet_id} have {subnet.available_ip_address_count} available IP addresses"
+                f"Subnet ID {subnet_id} has {subnet.available_ip_address_count} available IP addresses"
             )
-            logger.info("Subnet ID %s have a %s available IP address", subnet_id, subnet.available_ip_address_count)
+            echo_info(f"Subnet ID {subnet_id} has {subnet.available_ip_address_count} available IP addresses")
             subnets.append({subnet_id: subnet.available_ip_address_count})
 
         if encountered_errors:
             report["preflight_status"] = False
             errors.append("Available IPs for Subnet verification failed")
-            logger.error("Available IPs for Subnet verification failed")
+            echo_error("Available IPs for Subnet verification failed")
             customer_report["subnet"].append("Available IP for Subnet verification failed")
             for _error in encountered_errors:
                 customer_report["subnet"].append(_error)
-                logger.error(_error)
+                echo_error(_error)
         else:
             customer_report["subnet"].append("Available IP for Subnet verified")
-            logger.info("Available IPs for Subnet verified")
+            echo_success("Available IPs for Subnet verified")
     except Exception as error:
         errors.append(f"Some error occurred while fetching subnet details {error}")
-        logger.error("Some error occurred while fetching subnet details %s", error)
+        echo_error(f"Some error occurred while fetching subnet details {error}")
         report["preflight_status"] = False
 
 
@@ -192,31 +186,31 @@ def cluster_roles(
     loading_config(cluster_name, region)
 
     try:
-        logger.info("Checking important cluster role are present or not .....")
+        echo_info("Checking important cluster role are present or not...")
         available: List[str] = []
         not_available: List[str] = []
         customer_report["cluster role"] = []
 
         if not_available:
             customer_report["cluster role"].append("Cluster role verification failed")
-            logger.info("Cluster role verification failed")
+            echo_error("Cluster role verification failed")
             report["preflight_status"] = False
             errors.append("Cluster role verification failed")
             for _item in not_available:
                 customer_report["cluster role"].append(f"{_item} role is not present in the cluster")
-                logger.info("%s role is not present in the cluster", _item)
+                echo_warning(f"{_item} role is not present in the cluster")
         else:
             customer_report["cluster role"].append("All cluster role needed successfully verified")
             for _item in available:
                 customer_report["cluster role"].append(f"{_item} role is present in cluster")
-                logger.info("%s role is present in the cluster", _item)
-            logger.info("All cluster role needed successfully verified")
+                echo_info("{_item} role is present in the cluster")
+            echo_success("All cluster role needed successfully verified")
     except Exception as error:
         errors.append(f"Some error occurred while checking the cluster roles available {error}")
         customer_report["cluster role"].append(
             f"Some error occurred while checking the cluster roles available {error}"
         )
-        logger.error("Some error occurred while checking the cluster roles available - Error: %s", error)
+        echo_error(f"Some error occurred while checking the cluster roles available - Error: {error}")
         report["preflight_status"] = False
 
 
@@ -228,31 +222,31 @@ def pod_security_policies(
     try:
         try:
             policy_v1_api = client.PolicyV1beta1Api()
-            logger.info("Pod Security Policies .....")
+            echo_info("Pod Security Policies...")
             ret = policy_v1_api.list_pod_security_policy(field_selector="metadata.name=eks.privileged")
         except AttributeError:
-            logger.info("Current kubernetes python client version doesn't support PSP - continuing...")
+            echo_warning("Current kubernetes python client version doesn't support PSP - continuing...")
             return
 
         if not ret.items:
             customer_report["pod security policy"] = "Pod Security Policy with eks.privileged role doesnt exists."
             report["preflight_status"] = False
             errors.append("Pod Security Policy with eks.privileged role doesnt exists.")
-            logger.info("Pod Security Policy with eks.privileged role doesnt exists.")
+            echo_warning("Pod Security Policy with eks.privileged role doesnt exists.")
 
         for item in ret.items:
             if item.metadata.name == "eks.privileged":
                 customer_report["pod security policy"] = "Pod Security Policy with eks.privileged role exists."
-                logger.info("Pod Security Policy with eks.privileged role exists.")
+                echo_success("Pod Security Policy with eks.privileged role exists.")
             else:
                 customer_report["pod security policy"] = "Pod Security Policy with eks.privileged role doesnt exists."
                 report["preflight_status"] = False
                 errors.append("Pod Security Policy with eks.privileged role doesnt exists.")
-                logger.info("Pod Security Policy with eks.privileged role doesnt exists.")
+                echo_warning("Pod Security Policy with eks.privileged role doesnt exists.")
     except Exception as error:
         errors.append(f"Some error occurred while checking for the policy security policies {error}")
         customer_report["pod security policy"] = "Some error occurred while checking for the policy security policies"
-        logger.error("Some error occurred while checking for the policy security policies %s", error)
+        echo_error(f"Some error occurred while checking for the policy security policies {error}")
         report["preflight_status"] = False
 
 
@@ -263,7 +257,6 @@ def addon_version(
     cluster_details: Dict[str, Any],
     report: Dict[str, Any],
     customer_report: Dict[str, Any],
-    pass_vpc: bool,
 ) -> None:
     """Check for compatibility between addon and control plane versions."""
     loading_config(cluster_name, region)
@@ -314,7 +307,7 @@ def addon_version(
     ]["certificate-authority"]
 
     try:
-        logger.info("Check addon version compatibility .....")
+        echo_info("Check addon version compatibility...")
         addons: List[Dict[str, Any]] = []
         report["addon_params"] = {}
         customer_report["addons"] = {"vpc-cni": {}, "kube-proxy": {}, "coredns": {}}
@@ -324,11 +317,11 @@ def addon_version(
         calico = apps_v1_api.list_namespaced_daemon_set("calico-system")
 
         if calico.items:
-            logger.info("Calico addon is present in cluster")
+            echo_info("Calico addon is present in cluster")
             check_pods_running("calico", report, errors, "calico-system")
 
         for daemon_set_item in daemon_set.items:
-            if daemon_set_item.metadata.name == "aws-node" and not pass_vpc:
+            if daemon_set_item.metadata.name == "aws-node":
                 version_str = (
                     daemon_set_item.spec.template.spec.containers[0].image.split("amazon-k8s-cni:v")[1].split("-")[0]
                 )
@@ -338,13 +331,13 @@ def addon_version(
                     "env": daemon_set_item.spec.template.spec.containers[0].env,
                 }
                 version = version_str.split(".")
-                logger.info("VPC CNI found version: %s - version_str: %s", version, version_str)
-                logger.info("Likely desired vpc-cni version: %s", cni_target_version)
+                echo_info(f"VPC CNI found version: {version} - version_str: {version_str}")
+                echo_info(f"Likely desired vpc-cni version: {cni_target_version}")
                 check_pods_running("aws-node", report, errors)
                 if int("".join(version)) >= 170:
                     addons.append({"name": "vpc-cni", "version": version_str, "update": False})
                     customer_report["addons"]["vpc-cni"]["version"] = "Up to date"
-                    logger.info("vpc-cni version up to date")
+                    echo_info(f"vpc-cni version up to date")
                     check_addons_params(
                         config,
                         "vpc-cni",
@@ -356,7 +349,7 @@ def addon_version(
                     )
                 else:
                     addons.append({"name": "vpc-cni", "version": version_str, "update": True})
-                    logger.info("vpc-cni version is not compatible")
+                    echo_warning("vpc-cni version is not compatible")
                     customer_report["addons"]["vpc-cni"][
                         "version"
                     ] = f"Version: {cni_target_version} not compatible with current cluster version: {version_str}"
@@ -372,14 +365,12 @@ def addon_version(
                     "env": daemon_set_item.spec.template.spec.containers[0].env,
                 }
                 check_pods_running("kube-proxy", report, errors)
-                logger.info(
-                    "Checking if kube-proxy target version: %s is equal to the current version: %s",
-                    proxy_target_version,
-                    version,
+                echo_info(
+                    f"Checking if kube-proxy target version: {proxy_target_version} is equal to the current version: {version}",
                 )
                 if proxy_target_version == version:
                     addons.append({"name": daemon_set_item.metadata.name, "version": version, "update": False})
-                    logger.info("kube-proxy version up to date")
+                    echo_info("kube-proxy version up to date")
                     customer_report["addons"][daemon_set_item.metadata.name]["version"] = "Up to date"
                     check_addons_params(
                         config,
@@ -392,7 +383,7 @@ def addon_version(
                     )
                 else:
                     addons.append({"name": daemon_set_item.metadata.name, "version": version, "update": True})
-                    logger.info("kube-proxy version not compatible")
+                    echo_warning("kube-proxy version not compatible")
                     customer_report["addons"][daemon_set_item.metadata.name][
                         "version"
                     ] = f"Version: {proxy_target_version} not compatible with current cluster version: {version}"
@@ -409,15 +400,13 @@ def addon_version(
                     "env": deployment_item.spec.template.spec.containers[0].env,
                 }
                 check_pods_running("coredns", report, errors)
-                logger.info(
-                    "Checking if coredns target version: %s is equal to the current version: %s",
-                    coredns_target_version,
-                    version,
+                echo_info(
+                    f"Checking if coredns target version: {coredns_target_version} is equal to the current version: {version}",
                 )
                 if coredns_target_version == version:
                     addons.append({"name": deployment_item.metadata.name, "version": version, "update": False})
                     customer_report["addons"][deployment_item.metadata.name]["version"] = "Up to date"
-                    logger.info("core-dns version up to date")
+                    echo_info("core-dns version up to date")
                     check_addons_params(
                         config,
                         deployment_item.metadata.name,
@@ -429,7 +418,7 @@ def addon_version(
                     )
                 else:
                     addons.append({"name": deployment_item.metadata.name, "version": version, "update": True})
-                    logger.info("core-dns version up not compatible")
+                    echo_warning("core-dns version up not compatible")
                     customer_report["addons"][deployment_item.metadata.name][
                         "version"
                     ] = f"Version: {coredns_target_version} not compatible with current cluster version: {version}"
@@ -437,7 +426,7 @@ def addon_version(
         customer_report["addons_version"] = addons
     except Exception as error:
         errors.append(f"Some error occurred while checking the addon version {error}")
-        logger.error("Some error occurred while checking the addon version - Error: %s", error)
+        echo_error(f"Some error occurred while checking the addon version - Error: {error}")
         report["preflight_status"] = False
 
 
@@ -452,19 +441,19 @@ def check_pods_running(addon: str, report: Dict[str, Any], errors: List[str], na
             if addon in pod.metadata.name:
                 count = count + 1
                 if pod.status.phase == "Running":
-                    logger.info("%s pod is running", addon)
+                    echo_info(f"{addon} pod is running")
                 else:
-                    logger.info("%s Pod is not running, it is in %s", addon, pod.status.phase)
+                    echo_info(f"{addon} Pod is not running, it is in {pod.status.phase}")
                     errors.append(f"{addon} Pod is not running, it is in {pod.status.phase}")
                     report["preflight_status"] = False
 
         if not count:
-            logger.error("%s pod is not present in the cluster", addon)
+            echo_error(f"{addon} pod is not present in the cluster")
             report["preflight_status"] = False
             errors.append(f"{addon} pod is not present in the cluster")
     except Exception as error:
         errors.append(f"Some error occurred while checking for addon pods to be running {error}")
-        logger.info("Some error occurred while checking for addon pods to be running - Error: %s", error)
+        echo_error(f"Some error occurred while checking for addon pods to be running - Error: {error}")
         report["preflight_status"] = False
 
 
@@ -479,7 +468,7 @@ def check_addons_params(
 ) -> None:
     """Check the volume mount and environment in cluster and original YAML for addons."""
     s3_config = yaml_data[name]
-    logger.info("************* Parameter check for %s *************", name)
+    echo_info(f"************* Parameter check for {name} *************")
     # Compare image name
     image_part_1 = config["image"].split(".ecr.")[0] == s3_config["image"].split(".ecr.")[0]
     image_part_2 = (
@@ -489,10 +478,10 @@ def check_addons_params(
     if image_part_1 and image_part_2:
         report["addon_params"][name] = {"image": config["image"]}
         customer_report["addons"][name]["image"] = "Image Verified"
-        logger.info("Image verified")
+        echo_success("Image verified")
     else:
         customer_report["addons"][name]["image"] = "Image Verification Failed"
-        logger.error("Image verification failed")
+        echo_error("Image verification failed")
 
     # Compare Volume Mounts
     mount_paths = []
@@ -514,19 +503,19 @@ def check_addons_params(
         report["addon_params"][name]["mount_paths"]["custom"] = True
         report["addon_params"][name]["mount_paths"]["default"] = " ".join(map(str, mount_paths))
         customer_report["addons"][name]["mount_paths"]["default-mountpaths"] = " ".join(map(str, mount_paths))
-        logger.info("These mount paths are not present %s", " ".join(map(str, mount_paths)))
+        echo_warning(f"These mount paths are not present {' '.join(map(str, mount_paths))}")
 
     if remaining:
         customer_report["addons"][name]["mount_paths"]["message"] = "There are additional mount paths present"
         report["addon_params"][name]["mount_paths"]["custom"] = True
         report["addon_params"][name]["mount_paths"]["user-defined"] = " ".join(map(str, mount_paths))
         customer_report["addons"][name]["mount_paths"]["userdefined-mountpaths"] = " ".join(map(str, mount_paths))
-        logger.info("These user defined mount paths are present %s", " ".join(map(str, mount_paths)))
+        echo_warning(f"These user defined mount paths are present {' '.join(map(str, mount_paths))}")
 
     if not mount_paths and not remaining:
         report["addon_params"][name]["mount_paths"]["custom"] = False
         customer_report["addons"][name]["mount_paths"]["message"] = "Mount paths verified successfully"
-        logger.info("Mount path verification successful")
+        echo_success("Mount path verification successful")
 
     # Compare env
     if name == "vpc-cni":
@@ -549,19 +538,19 @@ def check_addons_params(
             report["addon_params"][name]["envs"]["custom"] = True
             report["addon_params"][name]["envs"]["default"] = " ".join(map(str, envs))
             customer_report["addons"][name]["env"]["default-envs"] = " ".join(map(str, envs))
-            logger.info("These envs are not present %s", " ".join(map(str, envs)))
+            echo_warning(f"These envs are not present: {' '.join(map(str, envs))}")
 
         if extra_envs:
             report["addon_params"][name]["envs"]["custom"] = True
             report["addon_params"][name]["envs"]["user-defined"] = " ".join(map(str, extra_envs))
             customer_report["addons"][name]["env"]["message"] = "There are additional envs present"
-            logger.info("These user defined envs are present %s", " ".join(map(str, extra_envs)))
+            echo_warning(f"These user defined envs are present {' '.join(map(str, extra_envs))}")
             customer_report["addons"][name]["env"]["userdefined-envs"] = " ".join(map(str, extra_envs))
 
         if not envs and not extra_envs:
             report["addon_params"][name]["envs"]["custom"] = False
             customer_report["addons"][name]["env"]["message"] = "Envs verified successfully"
-            logger.info("Envs verification successful")
+            echo_success("Envs verification successful")
 
     if name == "coredns":
         customer_report["addons"][name]["corefile"] = {}
@@ -586,7 +575,7 @@ def check_addons_params(
         for i in arr:
             if corefile.find(i) == -1:
                 default.append(i)
-                logger.info("%s doesnt exist in corefile", i)
+                echo_info(f"{i} doesn't exist in corefile")
             else:
                 corefile = corefile.replace(i, "")
         corefile = corefile.replace(" ", "")
@@ -596,19 +585,19 @@ def check_addons_params(
             report["addon_params"][name]["corefile"]["custom"] = True
             report["addon_params"][name]["corefile"]["default"] = " ".join(map(str, default))
             customer_report["addons"][name]["corefile"]["default-corefile-fields"] = " ".join(map(str, default))
-            logger.info("Default corefile fields are not present %s", " ".join(map(str, default)))
+            echo_warning(f"Default corefile fields are not present {' '.join(map(str, default))}")
 
         if corefile:
             customer_report["addons"][name]["corefile"]["message"] = "There are additional fields present in corefile"
             report["addon_params"][name]["corefile"]["custom"] = True
             report["addon_params"][name]["corefile"]["userdefined"] = " ".join(map(str, corefile))
             customer_report["addons"][name]["corefile"]["userdefined-corefile-fields"] = " ".join(map(str, corefile))
-            logger.info("Additional fields in corefile %s", " ".join(map(str, corefile)))
+            echo_warning(f"Additional fields in corefile {' '.join(map(str, corefile))}")
 
         if not corefile and not default:
             report["addon_params"][name]["corefile"]["custom"] = False
             customer_report["addons"][name]["corefile"]["message"] = "Corefile fields verified successfully"
-            logger.info("Corefile verified successfully")
+            echo_success("Corefile verified successfully")
 
     if name == "kube-proxy":
         report["addon_params"][name]["certificate-authority"] = {}
@@ -627,7 +616,7 @@ def check_addons_params(
                 "message"
             ] = "Certificate Authority Verified in kube config"
             report["addon_params"][name]["certificate-authority"]["certificate"] = config_map["certificate-authority"]
-            logger.info("Certificate Authority Verified in kube config")
+            echo_success("Certificate Authority Verified in kube config")
         else:
             customer_report["addons"][name]["certificate-authority"][
                 "message"
@@ -636,7 +625,7 @@ def check_addons_params(
             report["addon_params"][name]["certificate-authority"]["certificate"] = yaml.safe_load(
                 ret.items[0].data["kubeconfig"]
             )["clusters"][0]["cluster"]["certificate-authority"]
-            logger.info("Certificate Verification failed in kube config")
+            echo_error("Certificate Verification failed in kube config")
 
         if (
             yaml.safe_load(ret.items[0].data["kubeconfig"])["clusters"][0]["cluster"]["server"]
@@ -647,14 +636,14 @@ def check_addons_params(
             report["addon_params"][name]["server-endpoint"]["server-endpoint"] = cluster_details["cluster"][
                 "endpoint"
             ].lower()
-            logger.info("Server end point verified")
+            echo_success("Server end point verified")
         else:
             customer_report["addons"][name]["server-endpoint"]["message"] = "Server end point verification failed"
             report["addon_params"][name]["certificate-authority"]["verified"] = False
             report["addon_params"][name]["certificate-authority"]["server-endpoint"] = yaml.safe_load(
                 ret.items[0].data["kubeconfig"]
             )["clusters"][0]["cluster"]["server"]
-            logger.info(" Server end point verification failed")
+            echo_error("Server end point verification failed")
 
 
 def pod_disruption_budget(
@@ -667,19 +656,19 @@ def pod_disruption_budget(
 ) -> None:
     """Get pod disruption budgets."""
     loading_config(cluster_name, region)
-    logger.info("Fetching Pod Disruption Budget Details....")
+    echo_info("Fetching Pod Disruption Budget Details...")
     try:
         policy_v1_api = client.PolicyV1Api()
         ret = policy_v1_api.list_pod_disruption_budget_for_all_namespaces()
         if not ret.items:
             customer_report["pod disruption budget"] = "No Pod Disruption Budget exists in cluster"
-            logger.info("No Pod Disruption Budget exists in cluster")
+            echo_success("No Pod Disruption Budget exists in cluster")
         else:
-            logger.info(
+            echo_warning(
                 "Pod Disruption Budget exists in cluster therefore force upgrade is required to upgrade the cluster"
             )
             if not force_upgrade:
-                logger.info(
+                echo_warning(
                     "Pod Disruption Budget exists in cluster therefore force upgrade is required to upgrade the cluster, To upgrade please run the code with --force flag "
                 )
                 errors.append("To upgrade please run the code with --force flag ")
@@ -689,10 +678,8 @@ def pod_disruption_budget(
                 min_available = pdb.spec.min_available
                 report["pdb"] = {"max_unavailable": max_available, "min_available": min_available}
                 customer_report["pod disruption budget"] = "Pod disruption budget exists in the cluster"
-                logger.info(
-                    "Pod disruption budget exists with max unavailable as %s and min available as %s",
-                    str(max_available),
-                    str(min_available),
+                echo_warning(
+                    f"Pod disruption budget exists with max unavailable as {max_available} and min available as {min_available}",
                 )
             core_v1_api = client.CoreV1Api()
             pods_and_nodes = []
@@ -707,7 +694,7 @@ def pod_disruption_budget(
     except Exception as error:
         errors.append(f"Error occurred while checking for pod disruption budget {error}")
         customer_report["pod disruption budget"] = "Error occurred while checking for pod disruption budget"
-        logger.error("Error occurred while checking for pod disruption budget - Error: %s", error)
+        echo_error(f"Error occurred while checking for pod disruption budget - Error: {error}")
         report["preflight_status"] = False
 
 
@@ -716,7 +703,7 @@ def cluster_auto_scaler(
 ) -> None:
     """Get cluster autoscaler details."""
     loading_config(cluster_name, region)
-    logger.info("Fetching Cluster Auto Scaler Details....")
+    echo_info("Fetching Cluster Auto Scaler Details...")
     try:
         eks = boto3.client("eks", region_name=region)
         cluster_details = eks.describe_cluster(name=cluster_name)
@@ -727,7 +714,7 @@ def cluster_auto_scaler(
         for i in res.items:
             x = i.metadata.name
             if x == "cluster-autoscaler":
-                logger.info("Cluster Autoscaler exists")
+                echo_info("Cluster Autoscaler exists")
                 check_pods_running("cluster-autoscaler", report, errors)
                 version = (
                     i.spec.template.spec.containers[0]
@@ -738,38 +725,38 @@ def cluster_auto_scaler(
                 if l[0] == l1[0] and l[1] == l1[1]:
                     report["cluster_auto_scaler"] = {"image": i.spec.template.spec.containers[0].image}
                     customer_report["cluster autoscaler"] = "Auto scaler version is compatible with cluster version!"
-                    logger.info("Auto scaler version is compatible with cluster version!")
+                    echo_success("Auto scaler version is compatible with cluster version!")
                 else:
-                    logger.info("Auto scaler version is not compatible with cluster version")
+                    echo_warning("Auto scaler version is not compatible with cluster version")
                     customer_report["cluster autoscaler"] = "Auto scaler version is not compatible with cluster version"
                 return
             else:
                 continue
         customer_report["cluster autoscaler"] = "Cluster Autoscaler doesn't exist"
-        logger.info("Cluster Autoscaler doesn't exist")
+        echo_info("Cluster Autoscaler doesn't exist")
     except Exception as error:
         errors.append(f"Error occurred while checking for the cluster autoscaler {error}")
         customer_report["cluster autoscaler"] = f"Error occurred while checking for the cluster autoscaler {error}"
-        logger.error("Error occurred while checking for the cluster autoscaler - Error: %s", error)
+        echo_error(f"Error occurred while checking for the cluster autoscaler - Error: {error}")
         report["preflight_status"] = False
 
 
 def horizontal_auto_scaler(errors, cluster_name, region, report, customer_report):
     loading_config(cluster_name, region)
-    logger.info("Fetching Horizontal Autoscaler Details....")
+    echo_info("Fetching Horizontal Autoscaler Details...")
     try:
         v1 = client.AutoscalingV1Api()
         ret = v1.list_horizontal_pod_autoscaler_for_all_namespaces()
         if not ret.items:
             customer_report["horizontal auto scaler"] = "No Horizontal Auto Scaler exists in cluster"
-            logger.info("No Horizontal Auto Scaler exists in cluster")
+            echo_info("No Horizontal Auto Scaler exists in cluster")
         else:
             customer_report["horizontal auto scaler"] = "Horizontal Pod Auto scaler exists in cluster"
-            logger.info("Horizontal Pod Auto scaler exists in cluster")
+            echo_info("Horizontal Pod Auto scaler exists in cluster")
             report["horizontal_autoscaler"] = ret.items[0]
     except Exception as e:
         errors.append(f"Error occurred while checking for horizontal autoscaler {e}")
-        logger.error("Error occurred while checking for horizontal autoscaler - Error: %s", e)
+        echo_error(f"Error occurred while checking for horizontal autoscaler - Error: {e}")
         customer_report["horizontal auto scaler"] = "Error occurred while checking for horizontal autoscaler"
         report["preflight_status"] = False
 
@@ -777,12 +764,12 @@ def horizontal_auto_scaler(errors, cluster_name, region, report, customer_report
 def cmk_key_check(errors, cluster_name, region, cluster, report, customer_report):
     loading_config(cluster_name, region)
     cmk = boto3.client("kms", region_name=region)
-    logger.info("Checking if customer management key exists....")
+    echo_info("Checking if customer management key exists...")
     try:
         if "encryptionConfig" in cluster["cluster"].keys():
             cmk_key = cluster["cluster"]["encryptionConfig"][0]["provider"]["keyArn"]
             customer_report["CMK Key"] = f"CMK Key with id {cmk_key} is present"
-            logger.info("CMK Key with id %s is present", cmk_key)
+            echo_info(f"CMK Key with id {cmk_key} is present")
             response = cmk.describe_key(KeyId=cmk_key)
             try:
                 response = cmk.describe_key(
@@ -790,35 +777,35 @@ def cmk_key_check(errors, cluster_name, region, cluster, report, customer_report
                 )
                 if "KeyId" in response["KeyMetadata"].keys():
                     customer_report["CMK Key"] = f"Key with id {cmk_key} exist in user account"
-                    logger.info("Key with id %s exist in user account", cmk_key)
+                    echo_success(f"Key with id {cmk_key} exist in user account")
                 else:
                     report["preflight_status"] = False
                     errors.append(f"Key with id {cmk_key} doesnt exist in user account")
                     customer_report["CMK Key"] = f"Key with id {cmk_key} doesnt exist in user account"
-                    logger.info("Key with id %s doesnt exist in user account", cmk_key)
-            except:
+                    echo_error(f"Key with id {cmk_key} doesnt exist in user account")
+            except Exception:
                 report["preflight_status"] = False
                 errors.append(f"Key with id {cmk_key} doesnt exist in user account")
                 customer_report["CMK Key"] = f"Key with id {cmk_key} doesnt exist in user account"
-                logger.info("Key with id %s doesnt exist in user account", cmk_key)
+                echo_error(f"Key with id {cmk_key} doesnt exist in user account")
         else:
             customer_report["CMK Key"] = "No CMK Key associated with the cluster"
-            logger.info("No CMK Key associated with the cluster")
+            echo_warning("No CMK Key associated with the cluster")
     except Exception as e:
         errors.append(f"Error while checking for cluster CMK key {e}")
         customer_report["CMK Key"] = "Error while checking for cluster CMK key"
-        logger.info("Error while checking for cluster CMK key - Error: %s", e)
+        echo_error(f"Error while checking for cluster CMK key - Error: {e}")
         report["preflight_status"] = False
 
 
 def security_group_check(errors, cluster_name, region, cluster, report, customer_report):
     loading_config(cluster_name, region)
-    logger.info("Fetching security group details .....")
+    echo_info("Fetching security group details...")
     try:
         security_groups = cluster["cluster"]["resourcesVpcConfig"]["securityGroupIds"]
         if not security_groups:
             customer_report["security group"] = "No security groups available with cluster"
-            logger.info("No security groups available with cluster")
+            echo_warning("No security groups available with cluster")
         else:
             for s in security_groups:
                 try:
@@ -827,18 +814,18 @@ def security_group_check(errors, cluster_name, region, cluster, report, customer
                     customer_report[
                         "security group"
                     ] = f"Security Group {security_group.id} is present in VPC with ID {security_group.vpc_id}"
-                    logger.info(
-                        "Security Group %s is present in VPC with ID %s", security_group.id, security_group.vpc_id
+                    echo_success(
+                        f"Security Group {security_group.id} is present in VPC with ID {security_group.vpc_id}"
                     )
                 except Exception:
                     customer_report["security group"] = f"The security group with id {s} is not present"
                     report["preflight_status"] = False
                     errors.append(f"The security group with id {s} is not present")
-                    logger.error("The security group with id %s is not present", s)
+                    echo_error(f"The security group with id {s} is not present")
     except Exception as e:
         errors.append(f"Error retrieving security group of cluster {e}")
         customer_report["security group"] = f"Error retrieving security group of cluster {e}"
-        logger.info("Error retrieving security group of cluster - Error: %s", e)
+        echo_error(f"Error retrieving security group of cluster - Error: {e}")
         report["preflight_status"] = False
 
 
@@ -883,20 +870,19 @@ def iscustomami(node_type, Presentversion, image_id, region):
     for i in instances_list:
         if image_id in i[0]:
             return False
-    else:
-        return True
+    return True
 
 
 # Print nodegroup details
 def nodegroup_customami(errors, cluster_name, region, report, customer_report, update_version):
     loading_config(cluster_name, region)
     final_dict = {"self-managed": {}, "managed": {}, "fargate": {}}
-    logger.info("Fetching node group details ......")
+    echo_info("Fetching node group details...")
     try:
         v1 = client.CoreV1Api()
         ret = v1.list_node()
         if not ret.items:
-            logger.error("No running nodes present in the cluster!")
+            echo_error("No running nodes present in the cluster!")
             raise Exception("No running nodes present in the cluster")
 
         for i in ret.items:
@@ -931,11 +917,11 @@ def nodegroup_customami(errors, cluster_name, region, report, customer_report, u
                 else:
                     version_compatibility = False
                 if custom_ami:
-                    logger.error("%s cannot be upgraded as it has custom ami", instance_id)
+                    echo_error(f"{instance_id} cannot be upgraded as it uses a custom AMI!")
                 if not version_compatibility:
                     report["preflight_status"] = False
-                    logger.error(
-                        "%s cannot be upgraded as cluster version is not compatible with node version", instance_id
+                    echo_error(
+                        f"{instance_id} cannot be upgraded because the cluster version is not compatible with the node version",
                     )
                 if "alpha.eksctl.io/instance-id" in x or "eks.amazonaws.com/nodegroup" not in x:
                     if autoscale_group_name not in final_dict["self-managed"].keys():
@@ -973,7 +959,7 @@ def nodegroup_customami(errors, cluster_name, region, report, customer_report, u
                         eks = boto3.client("eks", region_name=region)
                         response = eks.describe_nodegroup(clusterName=cluster_name, nodegroupName=node_group_name)
                         if response["nodegroup"]["amiType"] == "CUSTOM":
-                            logger.error("Nodegroup cannot be upgraded as it has custom launch template")
+                            echo_error("Nodegroup cannot be upgraded as it has custom launch template")
                         final_dict["managed"][autoscale_group_name] = {
                             "nodegroup_name": node_group_name,
                             "custom_launch_template": response["nodegroup"]["amiType"] == "CUSTOM",
@@ -1002,6 +988,6 @@ def nodegroup_customami(errors, cluster_name, region, report, customer_report, u
         return final_dict
     except Exception as e:
         errors.append(f"Error occurred while checking node group details {e}")
-        logger.error("Error occurred while checking node group details - Error: %s", e)
+        echo_error(f"Error occurred while checking node group details - Error: {e}")
         customer_report["node group details"] = "Error occurred while checking node group details"
         report["preflight_status"] = False

--- a/eksupgrade/starter.py
+++ b/eksupgrade/starter.py
@@ -3,14 +3,11 @@ from __future__ import annotations
 
 import datetime
 import queue
-import sys
 import threading
 import time
 
-from eksupgrade.utils import get_logger
+from eksupgrade.utils import echo_error, echo_info, echo_success, get_logger
 
-from .exceptions import ClusterInactiveException
-from .models.eks import Cluster
 from .src.boto_aws import (
     add_autoscaling,
     add_node,
@@ -22,16 +19,8 @@ from .src.boto_aws import (
     worker_terminate,
 )
 from .src.eks_get_image_type import get_ami_name
-from .src.k8s_client import (
-    cluster_auto_enable_disable,
-    delete_node,
-    drain_nodes,
-    find_node,
-    is_cluster_auto_scaler_present,
-    unschedule_old_nodes,
-)
+from .src.k8s_client import delete_node, drain_nodes, find_node, unschedule_old_nodes
 from .src.latest_ami import get_latest_ami
-from .src.preflight_module import pre_flight_checks
 from .src.self_managed import update_nodegroup
 
 logger = get_logger(__name__)
@@ -53,12 +42,12 @@ class StatsWorker(threading.Thread):
         while self.queue.not_empty:
             cluster_name, ng_name, to_update, region, max_retry, forced, typse = self.queue.get()
             if typse == "managed":
-                logger.info("Updating node group: %s to version: %s", ng_name, to_update)
+                echo_info(f"Updating node group: {ng_name} to version: {to_update}")
                 update_nodegroup(cluster_name, ng_name, to_update, region)
-                logger.info("Updated node group: %s to version: %s", ng_name, to_update)
+                echo_success(f"Updated node group: {ng_name} to version: {to_update}")
                 self.queue.task_done()
             elif typse == "selfmanaged":
-                logger.info("Updating node group: %s to version: %s", ng_name, to_update)
+                echo_info(f"Updating node group: {ng_name} to version: {to_update}")
                 actual_update(
                     cluster_name=cluster_name,
                     asg_iter=ng_name,
@@ -67,25 +56,25 @@ class StatsWorker(threading.Thread):
                     max_retry=max_retry,
                     forced=forced,
                 )
-                logger.info("Updated node group: %s to version: %s", ng_name, to_update)
+                echo_success(f"Updated node group: {ng_name} to version: {to_update}")
                 self.queue.task_done()
 
 
 def actual_update(cluster_name, asg_iter, to_update, region, max_retry, forced):
     """Perform the update."""
     instance_type, image_to_search = get_ami_name(cluster_name, asg_iter, region)
-    logger.info("The Image Type Detected = %s", instance_type)
+    echo_info(f"The Image Type Detected = {instance_type}")
 
     if instance_type == "NAN":
         return False
     if isinstance(image_to_search, str) and "Windows_Server" in image_to_search:
         image_to_search = image_to_search[:46]
     latest_ami = get_latest_ami(to_update, instance_type, image_to_search, region)
-    logger.info("The Latest AMI Recommended = %s", latest_ami)
+    echo_info(f"The Latest AMI Recommended = {latest_ami}")
 
     if get_outdated_asg(asg_iter, latest_ami, region):
         add_autoscaling(asg_iter, latest_ami, region)
-        logger.info("New Launch Configuration Added to = %s With EKS AMI = %s", asg_iter, latest_ami)
+        echo_info(f"New Launch Configuration Added to = {asg_iter} With EKS AMI = {latest_ami}")
 
     outdated_instances = outdated_lt(asg_iter, region)
     if not outdated_instances:
@@ -93,17 +82,17 @@ def actual_update(cluster_name, asg_iter, to_update, region, max_retry, forced):
 
     try:
         terminated_ids = []
-        logger.info("The Outdate Instance Found Are = %s", outdated_instances)
+        echo_info(f"The Outdate Instance Found Are = {outdated_instances}")
         for instance in outdated_instances:
             before_count = get_num_of_instances(asg_iter, terminated_ids, region)
-            logger.info("Total Instance count = %s", before_count)
+            echo_info(f"Total Instance count = {before_count}")
             add_time = datetime.datetime.now(datetime.timezone.utc)
 
             if abs(before_count - len(outdated_instances)) != len(outdated_instances):
                 add_node(asg_iter, region)
                 time.sleep(45)
                 latest_instance = get_latest_instance(asg_name=asg_iter, add_time=add_time, region=region)
-                logger.info("The Instance Created = %s and waiting for it to be ready", latest_instance)
+                echo_info(f"The Instance Created = {latest_instance} and waiting for it to be ready")
                 time.sleep(30)
                 wait_for_ready(latest_instance, region)
 
@@ -121,145 +110,21 @@ def actual_update(cluster_name, asg_iter, to_update, region, max_retry, forced):
                         time.sleep(10)
                 if flag == 0:
                     worker_terminate(instance, region=region)
+                    echo_error("404 instance is not corresponded to particular node group")
                     raise Exception("404 instance is not corresponded to particular node group")
 
-            logger.info("Unscheduling the worker node = %s", old_pod_id)
+            echo_info(f"Unscheduling the worker node = {old_pod_id}")
 
             unschedule_old_nodes(cluster_name=cluster_name, node_name=old_pod_id, region=region)
-            logger.info("The node: %s has been unscheduled! Worker Node Draining...", old_pod_id)
+            echo_info(f"The node: {old_pod_id} has been unscheduled! Worker Node Draining...")
             drain_nodes(cluster_name=cluster_name, node_name=old_pod_id, forced=forced, region=region)
-            logger.info("The worker node has been drained! Deleting worker Node Started = %s", old_pod_id)
+            echo_info(f"The worker node has been drained! Deleting worker Node Started = {old_pod_id}")
             delete_node(cluster_name=cluster_name, node_name=old_pod_id, region=region)
-            logger.info("The worker node: %s has been deleted. Terminating Worker Node: %s...", old_pod_id, instance)
+            echo_info(f"The worker node: {old_pod_id} has been deleted. Terminating Worker Node: {instance}...")
             worker_terminate(instance, region=region)
             terminated_ids.append(instance)
-            logger.info("The worker node instance: %s has been terminated!", instance)
+            echo_success(f"The worker node instance: {instance} has been terminated!")
         return True
     except Exception as e:
-        logger.error("Error encountered during actual update! Exception: %s", e)
+        echo_error(f"Error encountered during actual update! Exception: {e}")
         raise e
-
-
-def main(args) -> None:
-    """Handle the main workflow for eks update."""
-    is_present = False
-    cluster_name = args.name
-    to_update = args.version
-    pass_vpc = args.pass_vpc
-    max_retry = args.max_retry
-    region = args.region
-    forced = args.force
-    paralleled = args.parallel
-    preflight = args.preflight
-    use_latest_addons = args.latest_addons
-    disable_checks = args.disable_checks
-    replicas_value = 0
-
-    try:
-        # Preflight Logic
-        if not disable_checks:
-            if not pre_flight_checks(True, cluster_name, region, pass_vpc, args.version, args.force):
-                logger.error("Pre-flight check for cluster %s failed!", cluster_name)
-                sys.exit()
-            else:
-                logger.info("Pre-flight check for the cluster %s succeeded!", cluster_name)
-            if preflight:
-                sys.exit()
-        else:
-            logger.info("Pre-flight check was disabled and didn't run.")
-
-        # upgrade Logic
-        logger.info("The cluster upgrade process has started")
-
-        target_cluster: Cluster = Cluster.get(
-            cluster_name=cluster_name, region=region, target_version=to_update, latest_addons=use_latest_addons
-        )
-
-        if not target_cluster.available:
-            raise ClusterInactiveException("The cluster is not active")
-
-        logger.info("The current version of the cluster was detected as: %s", target_cluster.version)
-
-        # Checking Cluster is Active or Not Before Making an Update
-        if target_cluster.active:
-            target_cluster.update_cluster(wait=True)
-        else:
-            logger.warning(
-                "The target EKS cluster: %s isn't currently active - status: %s",
-                target_cluster.name,
-                target_cluster.status,
-            )
-            target_cluster.wait_for_active()
-
-        # Managed Node Groups
-        logger.info("The Manged Node Groups Found are %s", ",".join(target_cluster.nodegroup_names))
-        managed_nodegroup_asgs: list[str] = []
-        for nodegroup in target_cluster.nodegroups:
-            managed_nodegroup_asgs += nodegroup.autoscaling_group_names
-
-        # removing self-managed from managed so that we don't update them again
-        asg_list_self_managed = list(set(target_cluster.asg_names) - set(managed_nodegroup_asgs))
-
-        # addons update
-        target_cluster.upgrade_addons(wait=True)
-
-        # checking auto scaler present and the value associated from it
-        is_present, replicas_value = is_cluster_auto_scaler_present(cluster_name=cluster_name, region=region)
-
-        if is_present:
-            cluster_auto_enable_disable(
-                cluster_name=cluster_name, operation="pause", mx_val=replicas_value, region=region
-            )
-            logger.info("Paused the Cluster AutoScaler")
-        else:
-            logger.info("No Cluster AutoScaler is Found")
-        if paralleled:
-            for x in range(20):
-                worker = StatsWorker(queue, x)
-                worker.setDaemon(True)
-                worker.start()
-
-        if target_cluster.upgradable_managed_nodegroups:
-            logger.info("The outdated managed nodegroups = %s", target_cluster.upgradable_managed_nodegroups)
-        else:
-            logger.info("No outdated managed nodegroups found!")
-
-        target_cluster.upgrade_nodegroups(wait=not paralleled)
-
-        # TODO: Use custom_ami to update launch templates and re-roll self-managed nodes under ASGs.
-        for asg_iter in asg_list_self_managed:
-            if paralleled:
-                queue.put([cluster_name, asg_iter, to_update, region, max_retry, forced, "selfmanaged"])
-            else:
-                actual_update(cluster_name, asg_iter, to_update, region, max_retry, forced)
-
-        if paralleled:
-            queue.join()
-
-        if is_present:
-            cluster_auto_enable_disable(
-                cluster_name=cluster_name, operation="start", mx_val=replicas_value, region=region
-            )
-            logger.info("Cluster Autoscaler is Enabled Again")
-        logger.info("EKS Cluster %s UPDATED TO %s", cluster_name, to_update)
-        logger.info("Post flight check for the upgraded cluster")
-
-        if not disable_checks:
-            if not pre_flight_checks(
-                preflight=False, cluster_name=cluster_name, region=region, pass_vpc=pass_vpc, force_upgrade=forced
-            ):
-                logger.info("Post flight check for cluster %s failed after it upgraded", cluster_name)
-            else:
-                logger.info("After update check for cluster completed successfully")
-        else:
-            logger.info("Post-flight check was disabled and didn't run.")
-    except Exception as error:
-        if is_present:
-            try:
-                cluster_auto_enable_disable(
-                    cluster_name=cluster_name, operation="start", mx_val=replicas_value, region=region
-                )
-                logger.info("Cluster Autoscaler is Enabled Again")
-            except Exception as error2:
-                logger.error("Autoenable failed and must be done manually! Error: %s", error2)
-        logger.error("Exception encountered in main method - Error: %s", error)

--- a/eksupgrade/utils.py
+++ b/eksupgrade/utils.py
@@ -31,18 +31,18 @@ def get_logger(logger_name):
     return logger
 
 
-def confirm(message: str) -> bool:
-    """Prompt the user with a confirmation dialog with the provided message."""
+def confirm(message: str, abort: bool = True) -> bool:
+    """Prompt the user with a confirmation dialog with the provided message.
+
+    Raises:
+        typer.Abort: The exception is raised when abort=True and confirmation fails.
+
+    Returns:
+        bool: Whether or not the prompt was confirmed.
+
+    """
     text = typer.style(message, fg=typer.colors.BRIGHT_BLUE, bold=True, bg=typer.colors.WHITE)
-    return typer.confirm(text)
-
-
-def interactive_confirm(message: str, interactive: bool = True) -> None:
-    """Prompt the user with a confirmation dialog with the provided message."""
-    if interactive:
-        _confirmation = confirm(message=message)
-        if not _confirmation:
-            raise typer.Abort()
+    return typer.confirm(text, abort=abort)
 
 
 def echo_error(message: str) -> None:

--- a/eksupgrade/utils.py
+++ b/eksupgrade/utils.py
@@ -4,6 +4,8 @@ import logging
 import pkgutil
 import sys
 
+import typer
+
 
 def get_package_asset(filename: str, base_path: str = "src/S3Files/") -> str:
     """Get the specified package asset data."""
@@ -17,7 +19,7 @@ def get_package_dict(filename: str, base_path: str = "src/S3Files/"):
 
 
 def get_logger(logger_name):
-    """Get a logger object with handler set to StreamHandler"""
+    """Get a logger object with handler set to StreamHandler."""
     logger = logging.getLogger(logger_name)
     console_handler = logging.StreamHandler(sys.stdout)
     log_formatter = logging.Formatter(
@@ -27,3 +29,37 @@ def get_logger(logger_name):
     logger.addHandler(console_handler)
     logger.propagate = False
     return logger
+
+
+def confirm(message: str) -> bool:
+    """Prompt the user with a confirmation dialog with the provided message."""
+    text = typer.style(message, fg=typer.colors.BRIGHT_BLUE, bold=True, bg=typer.colors.WHITE)
+    return typer.confirm(text)
+
+
+def interactive_confirm(message: str, interactive: bool = True) -> None:
+    """Prompt the user with a confirmation dialog with the provided message."""
+    if interactive:
+        _confirmation = confirm(message=message)
+        if not _confirmation:
+            raise typer.Abort()
+
+
+def echo_error(message: str) -> None:
+    """Echo a message as an error."""
+    typer.secho(message, fg=typer.colors.WHITE, bg=typer.colors.RED, bold=True, blink=True, err=True)
+
+
+def echo_success(message: str) -> None:
+    """Echo a message as an error."""
+    typer.secho(message, fg=typer.colors.WHITE, bg=typer.colors.GREEN, bold=True, blink=True)
+
+
+def echo_info(message: str) -> None:
+    """Echo a message as an error."""
+    typer.secho(message, fg=typer.colors.BRIGHT_BLUE)
+
+
+def echo_warning(message: str) -> None:
+    """Echo a message as an error."""
+    typer.secho(message, fg=typer.colors.BRIGHT_YELLOW, bold=True, blink=True)

--- a/poetry.lock
+++ b/poetry.lock
@@ -712,7 +712,7 @@ files = [
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -727,13 +727,28 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+
+[[package]]
+name = "commonmark"
+version = "0.9.1"
+description = "Python parser for the CommonMark Markdown spec"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
+    {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
+]
+
+[package.extras]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "coverage"
@@ -1545,6 +1560,21 @@ snowballstemmer = ">=2.2.0"
 toml = ["tomli (>=1.2.3)"]
 
 [[package]]
+name = "pygments"
+version = "2.14.0"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"},
+    {file = "Pygments-2.14.0.tar.gz", hash = "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297"},
+]
+
+[package.extras]
+plugins = ["importlib-metadata"]
+
+[[package]]
 name = "pylint"
 version = "2.16.4"
 description = "python code static checker"
@@ -1760,6 +1790,26 @@ urllib3 = ">=1.25.10"
 tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "types-requests"]
 
 [[package]]
+name = "rich"
+version = "12.6.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+category = "main"
+optional = false
+python-versions = ">=3.6.3,<4.0.0"
+files = [
+    {file = "rich-12.6.0-py3-none-any.whl", hash = "sha256:a4eb26484f2c82589bd9a17c73d32a010b1e29d89f1604cd9bf3a2097b81bb5e"},
+    {file = "rich-12.6.0.tar.gz", hash = "sha256:ba3a3775974105c221d31141f2c116f4fd65c5ceb0698657a11e9f295ec93fd0"},
+]
+
+[package.dependencies]
+commonmark = ">=0.9.0,<0.10.0"
+pygments = ">=2.6.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
+
+[[package]]
 name = "rsa"
 version = "4.9"
 description = "Pure-Python RSA implementation"
@@ -1897,6 +1947,18 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-202
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
+name = "shellingham"
+version = "1.5.0.post1"
+description = "Tool to Detect Surrounding Shell"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "shellingham-1.5.0.post1-py2.py3-none-any.whl", hash = "sha256:368bf8c00754fd4f55afb7bbb86e272df77e4dc76ac29dbcbb81a59e9fc15744"},
+    {file = "shellingham-1.5.0.post1.tar.gz", hash = "sha256:823bc5fb5c34d60f285b624e7264f4dda254bc803a3774a147bf99c0e3004a28"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -2003,6 +2065,30 @@ files = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.7.0"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "typer-0.7.0-py3-none-any.whl", hash = "sha256:b5e704f4e48ec263de1c0b3a2387cd405a13767d2f907f44c1a08cbad96f606d"},
+    {file = "typer-0.7.0.tar.gz", hash = "sha256:ff797846578a9f2a201b53442aedeb543319466870fbe1c701eab66dd7681165"},
+]
+
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+colorama = {version = ">=0.4.3,<0.5.0", optional = true, markers = "extra == \"all\""}
+rich = {version = ">=10.11.0,<13.0.0", optional = true, markers = "extra == \"all\""}
+shellingham = {version = ">=1.3.0,<2.0.0", optional = true, markers = "extra == \"all\""}
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
+doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
+test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+
+[[package]]
 name = "types-awscrt"
 version = "0.16.10"
 description = "Type annotations and code completion for awscrt"
@@ -2057,7 +2143,7 @@ files = [
 name = "typing-extensions"
 version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2217,4 +2303,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "3525168dcf4b7bf574e29bfd3cb2b7a4c6a48a9b4c2f288da416e947bb8a28a3"
+content-hash = "99e974e58ea297706e95f5c6c323fd14d7a98b00cb68e10b51d3aa3b0332b2dd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = [
 ]
 
 [tool.poetry.scripts]
-eksupgrade = "eksupgrade.cli:entry"
+eksupgrade = "eksupgrade.cli:app"
 
 [tool.bandit]
 exclude_dirs = ["tests"]
@@ -69,6 +69,7 @@ python = "^3.8"
 boto3 = "^1.26.84"
 kubernetes = ">=21.0.0 <25.0.0"
 packaging = ">=21.0,<22.0"
+typer = {extras = ["all"], version = "^0.7.0"}
 
 
 [tool.poetry.group.test.dependencies]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,24 +1,21 @@
 """Test the functionality of the CLI module."""
-import pytest
+from typer.testing import CliRunner
 
-from eksupgrade.cli import entry
+from eksupgrade.cli import app
+
+runner = CliRunner()
 
 
-def test_entry_version_arg(capsys) -> None:
+def test_entry_version_arg() -> None:
     """Test the entry method with version argument."""
-    with pytest.raises(SystemExit):
-        entry(["--version"])
-
-    captured = capsys.readouterr()
-    result = captured.out
-    assert result.startswith("eksupgrade")
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert "eksupgrade version" in result.stdout
 
 
-def test_entry_no_arg(capsys) -> None:
+def test_entry_no_arg() -> None:
     """Test the entry method with no arguments."""
-    with pytest.raises(SystemExit):
-        entry()
-
-    captured = capsys.readouterr()
-    result = captured.out
-    assert result.startswith("")
+    # with pytest.raises(SystemExit):
+    result = runner.invoke(app, [])
+    assert result.exit_code == 2
+    assert "OPTIONS" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,6 @@ def test_entry_version_arg() -> None:
 
 def test_entry_no_arg() -> None:
     """Test the entry method with no arguments."""
-    # with pytest.raises(SystemExit):
     result = runner.invoke(app, [])
     assert result.exit_code == 2
     assert "OPTIONS" in result.stdout


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

The goal of this PR is to swap out argparse with the more robust third-party module: `typer`, providing shell completion support, full `click` support, and much more.
Additionally, this PR enabled a confirmation prompt when executing eksupgrade following the pre-flight checks (requiring user input of y/N) and colorizes all outputs based on disposition of the operation originating the output.

Resolves: #31 

### Changes

Swaps out the logger usage throughout most of the project with `typer.secho` pre-canned variants in `eksupgrade.utils@echo_*`, adds the `--interactive`/`--no-interactive` flags to disable prompts, and updates the entry script to use typer.

### User experience

Colorized outputs based on status, shell completion support, clearer help text, and interactive/non-interactive workflows.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
