### PR TITLE
fix: Mismatch on Owner id for windows ami

### DIFF
--- a/eksupgrade/src/eks_get_image_type.py
+++ b/eksupgrade/src/eks_get_image_type.py
@@ -16,31 +16,18 @@ def image_type(node_type: str, image_id: str, region: str) -> Optional[str]:
     """Return the image location."""
     ec2_client = boto3.client("ec2", region_name=region)
     node_type = node_type.lower()
+    filters = [
+        {"Name": "is-public", "Values": ["true"]},
+    ]
 
     if node_type == "amazon linux 2":
-        filters = [
-            {"Name": "owner-id", "Values": ["602401143452"]},
-            {"Name": "name", "Values": ["amazon-eks-node-*"]},
-            {"Name": "is-public", "Values": ["true"]},
-        ]
+        filters.append({"Name": "name", "Values": ["amazon-eks-node-*"]})
     elif node_type == "ubuntu":
-        filters = [
-            {"Name": "owner-id", "Values": ["099720109477"]},
-            {"Name": "name", "Values": ["ubuntu-eks/k8s_*"]},
-            {"Name": "is-public", "Values": ["true"]},
-        ]
+        filters = {"Name": "name", "Values": ["ubuntu-eks/k8s_*"]}
     elif node_type == "bottlerocket":
-        filters = [
-            {"Name": "owner-id", "Values": ["092701018921"]},
-            {"Name": "name", "Values": ["bottlerocket-aws-k8s-*"]},
-            {"Name": "is-public", "Values": ["true"]},
-        ]
+        filters.append({"Name": "name", "Values": ["bottlerocket-aws-k8s-*"]})
     elif node_type == "windows":
-        filters = [
-            {"Name": "owner-id", "Values": ["801119661308"]},
-            {"Name": "name", "Values": ["Windows_Server-*-English-*-EKS_Optimized-*"]},
-            {"Name": "is-public", "Values": ["true"]},
-        ]
+        filters.append({"Name": "name", "Values": ["Windows_Server-*-English-*-EKS_Optimized-*"]})
     else:
         echo_warning(f"Node type: {node_type} is unsupported  - Image ID: {image_id}")
         return None

--- a/eksupgrade/src/eks_get_image_type.py
+++ b/eksupgrade/src/eks_get_image_type.py
@@ -23,7 +23,7 @@ def image_type(node_type: str, image_id: str, region: str) -> Optional[str]:
     if node_type == "amazon linux 2":
         filters.append({"Name": "name", "Values": ["amazon-eks-node-*"]})
     elif node_type == "ubuntu":
-        filters = {"Name": "name", "Values": ["ubuntu-eks/k8s_*"]}
+        filters.append({"Name": "name", "Values": ["ubuntu-eks/k8s_*"]})
     elif node_type == "bottlerocket":
         filters.append({"Name": "name", "Values": ["bottlerocket-aws-k8s-*"]})
     elif node_type == "windows":

--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -832,7 +832,7 @@ def security_group_check(errors, cluster_name, region, cluster, report, customer
 def iscustomami(node_type, Presentversion, image_id, region):
     filters = [{"Name": "is-public", "Values": ["true"]}]
 
-    if node_type in ["Amazon Linux 2"]:
+    if node_type == "Amazon Linux 2":
         filters.append({"Name": "name", "Values": [f"amazon-eks-node-{Presentversion}*"]})
     elif "ubuntu" in node_type.lower():
         filters.append({"Name": "name", "Values": [f"ubuntu-eks/k8s_{Presentversion}*"]})

--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -830,33 +830,16 @@ def security_group_check(errors, cluster_name, region, cluster, report, customer
 
 # Check if the AMI is custom
 def iscustomami(node_type, Presentversion, image_id, region):
-    if node_type == "Amazon Linux 2":
-        filters = [
-            {"Name": "owner-id", "Values": ["602401143452"]},
-            {"Name": "name", "Values": ["amazon-eks-node-{version}*".format(version=Presentversion)]},
-            {"Name": "is-public", "Values": ["true"]},
-        ]
+    filters = [{"Name": "is-public", "Values": ["true"]}]
+
+    if node_type in ["Amazon Linux 2"]:
+        filters.append({"Name": "name", "Values": [f"amazon-eks-node-{Presentversion}*"]})
     elif "ubuntu" in node_type.lower():
-        filters = [
-            {"Name": "owner-id", "Values": ["099720109477"]},
-            {"Name": "name", "Values": ["ubuntu-eks/k8s_{version}*".format(version=Presentversion)]},
-            {"Name": "is-public", "Values": ["true"]},
-        ]
+        filters.append({"Name": "name", "Values": [f"ubuntu-eks/k8s_{Presentversion}*"]})
     elif "bottlerocket" in node_type.lower():
-        filters = [
-            {"Name": "owner-id", "Values": ["092701018921"]},
-            {"Name": "name", "Values": ["bottlerocket-aws-k8s-{version}*".format(version=Presentversion)]},
-            {"Name": "is-public", "Values": ["true"]},
-        ]
+        filters.append({"Name": "name", "Values": [f"bottlerocket-aws-k8s-{Presentversion}*"]})
     elif "windows" in node_type.lower():
-        filters = [
-            {"Name": "owner-id", "Values": ["801119661308"]},
-            {
-                "Name": "name",
-                "Values": ["Windows_Server-*-English-*-EKS_Optimized-{version}*".format(version=Presentversion)],
-            },
-            {"Name": "is-public", "Values": ["true"]},
-        ]
+        filters.append({"Name": "name", "Values": [f"Windows_Server-*-English-*-EKS_Optimized-{Presentversion}*"]})
     else:
         return True
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
Updated the eks image check and custom ami verification paths to not be locked against the owner-ids which were from `us-east-1`. The owner-id specified for windows amis were not matching the actuals owner ids.  This is an interim fix as described in #92 before rolling out  additional changes.

Errors noticed:
With the filtered values( including the owner-id) in describe images call, the ami ids were being flagged as custom amis.
```
Pod Security Policy with eks.privileged role exists.
Fetching node group details...
i-011a9369a6162bd0f cannot be upgraded as it uses a custom AMI!
```

Tested against a cluster with Windows node and based out of `us-east-2` to verify that both the windows nodes and the owner id mapping were not causing any regressions.

Resolves: #92 

### Changes

Removed the owner id references from all the filters as this is region dependent. The additional filters were modified for readability.

**Note** :  With the filters removing the owner-ids which were previously there, the api call returns few more results than previously. This is to be updated in a later PR with the change in the model that is ongoing.


### User experience

Fixes the issue mentioned in #92 . Existing amis in a region should be identified.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [X] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
