### PR TITLE
fix: Adjust node_type check for get ami

### DIFF
--- a/eksupgrade/__init__.py
+++ b/eksupgrade/__init__.py
@@ -5,4 +5,4 @@ Attributes:
 
 """
 
-__version__: str = "0.8.1"
+__version__: str = "0.8.2"

--- a/eksupgrade/src/eks_get_image_type.py
+++ b/eksupgrade/src/eks_get_image_type.py
@@ -20,13 +20,14 @@ def image_type(node_type: str, image_id: str, region: str) -> Optional[str]:
         {"Name": "is-public", "Values": ["true"]},
     ]
 
-    if node_type == "amazon linux 2":
+    # TODO: Confirm if we should strip the 2 from this check for 2/2023.
+    if "amazon linux 2" in node_type:
         filters.append({"Name": "name", "Values": ["amazon-eks-node-*"]})
-    elif node_type == "ubuntu":
+    elif "ubuntu" in node_type:
         filters.append({"Name": "name", "Values": ["ubuntu-eks/k8s_*"]})
-    elif node_type == "bottlerocket":
+    elif "bottlerocket" in node_type:
         filters.append({"Name": "name", "Values": ["bottlerocket-aws-k8s-*"]})
-    elif node_type == "windows":
+    elif "windows" in node_type:
         filters.append({"Name": "name", "Values": ["Windows_Server-*-English-*-EKS_Optimized-*"]})
     else:
         echo_warning(f"Node type: {node_type} is unsupported  - Image ID: {image_id}")

--- a/eksupgrade/src/eks_get_image_type.py
+++ b/eksupgrade/src/eks_get_image_type.py
@@ -20,15 +20,12 @@ def image_type(node_type: str, image_id: str, region: str) -> Optional[str]:
         {"Name": "is-public", "Values": ["true"]},
     ]
 
-    # TODO: Confirm if we should strip the 2 from this check for 2/2023.
     if "amazon linux 2" in node_type:
-        filters.append({"Name": "name", "Values": ["amazon-eks-node-*"]})
-    elif "ubuntu" in node_type:
-        filters.append({"Name": "name", "Values": ["ubuntu-eks/k8s_*"]})
+        filters.append({"Name": "name", "Values": ["amazon-eks-node*"]})
     elif "bottlerocket" in node_type:
         filters.append({"Name": "name", "Values": ["bottlerocket-aws-k8s-*"]})
     elif "windows" in node_type:
-        filters.append({"Name": "name", "Values": ["Windows_Server-*-English-*-EKS_Optimized-*"]})
+        filters.append({"Name": "name", "Values": ["Windows_Server-*-English-*-EKS_Optimized*"]})
     else:
         echo_warning(f"Node type: {node_type} is unsupported  - Image ID: {image_id}")
         return None

--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -834,8 +834,6 @@ def iscustomami(node_type, Presentversion, image_id, region):
 
     if node_type == "Amazon Linux 2":
         filters.append({"Name": "name", "Values": [f"amazon-eks-node-{Presentversion}*"]})
-    elif "ubuntu" in node_type.lower():
-        filters.append({"Name": "name", "Values": [f"ubuntu-eks/k8s_{Presentversion}*"]})
     elif "bottlerocket" in node_type.lower():
         filters.append({"Name": "name", "Values": [f"bottlerocket-aws-k8s-{Presentversion}*"]})
     elif "windows" in node_type.lower():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eksupgrade"
-version = "0.8.1"
+version = "0.8.2"
 description = "The Amazon EKS cluster upgrade utility"
 authors = ["EKS Upgrade Maintainers <eks-upgrade-maintainers@amazon.com>"]
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from typing import Any, Generator
 
 import boto3
 import pytest
-from moto import mock_eks, mock_sts
+from moto import mock_ec2, mock_eks, mock_sts
 
 
 @pytest.fixture
@@ -27,6 +27,14 @@ def sts_client(aws_creds, region) -> Generator[Any, None, None]:
     """Mock the STS boto client."""
     with mock_sts():
         client = boto3.client("sts", region_name=region)
+        yield client
+
+
+@pytest.fixture
+def ec2_client(aws_creds, region) -> Generator[Any, None, None]:
+    """Mock the EKS boto client."""
+    with mock_ec2():
+        client = boto3.client("ec2", region_name=region)
         yield client
 
 

--- a/tests/test_eks_get_image_type.py
+++ b/tests/test_eks_get_image_type.py
@@ -15,6 +15,6 @@ from eksupgrade.src.eks_get_image_type import image_type
     ],
 )
 def test_image_type(ec2_client, region, node_type, image_id) -> None:
-    """Test the loading_config method."""
+    """Test the image_type method."""
     ami_id: Optional[str] = image_type(node_type=node_type, image_id=image_id, region=region)
     assert ami_id

--- a/tests/test_eks_get_image_type.py
+++ b/tests/test_eks_get_image_type.py
@@ -1,0 +1,20 @@
+"""Test EKS Upgrade get image type specific logic."""
+from typing import Optional
+
+import pytest
+
+from eksupgrade.src.eks_get_image_type import image_type
+
+
+@pytest.mark.parametrize(
+    "node_type,image_id",
+    [
+        ("windows server 2019 datacenter ", "ami-ekswin"),
+        ("windows server 2022", "ami-ekswin"),
+        ("amazon linux 2", "ami-ekslinux"),
+    ],
+)
+def test_image_type(ec2_client, region, node_type, image_id) -> None:
+    """Test the loading_config method."""
+    ami_id: Optional[str] = image_type(node_type=node_type, image_id=image_id, region=region)
+    assert ami_id


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

The goal of this PR is to resolve the `node_type` issue missing `windows` comparison for various distributions.

Resolves: #100

### Changes

Modifies the node_type check to match on varying windows distributions versus explicitly `== windows`

### User experience

Resolves failure to determine AMI.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
