### PR TITLE
test: Add pre/post-flight deprecation notice

### DIFF
--- a/eksupgrade/__init__.py
+++ b/eksupgrade/__init__.py
@@ -5,4 +5,4 @@ Attributes:
 
 """
 
-__version__: str = "0.8.2"
+__version__: str = "0.8.3"

--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -8,7 +8,7 @@ import urllib3
 import yaml
 from kubernetes import client
 
-from eksupgrade.utils import echo_error, echo_info, echo_success, echo_warning, get_package_dict
+from eksupgrade.utils import echo_deprecation, echo_error, echo_info, echo_success, echo_warning, get_package_dict
 
 from .k8s_client import get_default_version, loading_config
 
@@ -29,6 +29,9 @@ def pre_flight_checks(
     force_upgrade: bool = False,
 ) -> bool:
     """Handle the pre-flight checks."""
+    echo_deprecation(
+        f"Ths {'pre' if preflight else 'post'}-flight checks will be deprecated in the next minor release in favor of cluster summaries: #103"
+    )
     echo_info(f"Running validation checks against cluster: {cluster_name}...")
     loading_config(cluster_name, region)
     report: Dict[str, Any] = {"preflight_status": True}

--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -30,7 +30,7 @@ def pre_flight_checks(
 ) -> bool:
     """Handle the pre-flight checks."""
     echo_deprecation(
-        f"Ths {'pre' if preflight else 'post'}-flight checks will be deprecated in the next minor release in favor of cluster summaries: #103"
+        f"The {'pre' if preflight else 'post'}-flight checks will be deprecated in the next minor release in favor of cluster summaries: #103"
     )
     echo_info(f"Running validation checks against cluster: {cluster_name}...")
     loading_config(cluster_name, region)

--- a/eksupgrade/utils.py
+++ b/eksupgrade/utils.py
@@ -45,6 +45,11 @@ def confirm(message: str, abort: bool = True) -> bool:
     return typer.confirm(text, abort=abort)
 
 
+def echo_deprecation(message: str) -> None:
+    """Echo a message as a deprecation notice."""
+    typer.secho(message, fg=typer.colors.WHITE, bg=typer.colors.YELLOW, bold=True, blink=True)
+
+
 def echo_error(message: str) -> None:
     """Echo a message as an error."""
     typer.secho(message, fg=typer.colors.WHITE, bg=typer.colors.RED, bold=True, blink=True, err=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eksupgrade"
-version = "0.8.2"
+version = "0.8.3"
 description = "The Amazon EKS cluster upgrade utility"
 authors = ["EKS Upgrade Maintainers <eks-upgrade-maintainers@amazon.com>"]
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from typing import Any, Generator
 
 import boto3
 import pytest
+import typer
 from moto import mock_ec2, mock_eks, mock_sts
 
 
@@ -62,3 +63,9 @@ def eks_cluster(eks_client, cluster_name):
         resourcesVpcConfig={},
     )
     yield
+
+
+@pytest.fixture
+def app():
+    """Define the typer cli fixture."""
+    return typer.Typer()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,18 @@
 """Test the util logic."""
-from eksupgrade.utils import get_package_asset, get_package_dict
+from typer.testing import CliRunner
+
+from eksupgrade.utils import (
+    confirm,
+    echo_deprecation,
+    echo_error,
+    echo_info,
+    echo_success,
+    echo_warning,
+    get_package_asset,
+    get_package_dict,
+)
+
+runner = CliRunner()
 
 
 def test_get_package_asset() -> None:
@@ -19,3 +32,67 @@ def test_get_package_dict() -> None:
     """Test the get package dict method."""
     data = get_package_dict("version_dict.json")
     assert data["1.26"]["cluster-autoscaler"]
+
+
+def test_echo_deprecation(app) -> None:
+    """Test the echo deprecation method."""
+    app.command()(echo_deprecation)
+    result = runner.invoke(app, ["this is a deprecation"])
+    assert "this is a deprecation" in result.stdout
+    assert result.exit_code == 0
+
+
+def test_echo_error(app) -> None:
+    """Test the echo error method."""
+    app.command()(echo_error)
+    result = runner.invoke(app, ["this is a error"])
+    assert "this is a error" in result.stdout
+    assert result.exit_code == 0
+
+
+def test_echo_info(app) -> None:
+    """Test the echo info method."""
+    app.command()(echo_info)
+    result = runner.invoke(app, ["this is a info"])
+    assert "this is a info" in result.stdout
+    assert result.exit_code == 0
+
+
+def test_echo_success(app) -> None:
+    """Test the echo success method."""
+    app.command()(echo_success)
+    result = runner.invoke(app, ["this is a success"])
+    assert "this is a success" in result.stdout
+    assert result.exit_code == 0
+
+
+def test_echo_warning(app) -> None:
+    """Test the echo warning method."""
+    app.command()(echo_warning)
+    result = runner.invoke(app, ["this is a warning"])
+    assert "this is a warning" in result.stdout
+    assert result.exit_code == 0
+
+
+def test_confirm_yes(app) -> None:
+    """Test the confirm method with input y for yes."""
+    app.command()(confirm)
+    result = runner.invoke(app, ["this is a confirmation prompt"], input="y\n")
+    assert "this is a confirmation prompt" in result.stdout
+    assert result.exit_code == 0
+
+
+def test_confirm_no(app) -> None:
+    """Test the confirm method with input n for no."""
+    app.command()(confirm)
+    result = runner.invoke(app, ["this is a confirmation prompt"], input="n\n")
+    assert "this is a confirmation prompt" in result.stdout
+    assert result.exit_code == 1
+
+
+def test_confirm_no_without_abort(app) -> None:
+    """Test the confirm method with input n for no and abort disabled."""
+    app.command()(confirm)
+    result = runner.invoke(app, ["this is a confirmation prompt", "--no-abort"], input="n\n")
+    assert "this is a confirmation prompt" in result.stdout
+    assert result.exit_code == 0


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

The goal of this PR is to add a deprecation notice to the pre/post-flight checks regarding the deprecation and changes from #103 

Resolves: NA

### Changes

This PR adds test coverage for the remaining `utils.py` methods, adds the relevant deprecation notice to the pre/post-flight checks, and introduces the `echo_deprecation` method.

### User experience

When using `0.8.3`, a user running `eksupgrade <cluster-name> <version> <region> --preflight` or `eksupgrade <cluster-name> <version> <region>` will receive a notice stating:

`{Pre|Post}-flight checks will be deprecated in the next minor release in favor of cluster summaries: #103`

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
