### PR TITLE
feat: Added stale issue workflow

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -26,9 +26,9 @@ jobs:
         # Don't set closed-for-staleness label to skip closing very old issues regardless of label
         closed-for-staleness-label: closed-for-staleness
         # Issue timing
-        days-before-stale: 5
-        days-before-close: 10
-        days-before-ancient: 365
+        days-before-stale: 7
+        days-before-close: 14
+        days-before-ancient: 3
         # If you don't want to mark an issue as being ancient based on a threshold of "upvotes", you can set this here.
         # An "upvote" is the total number of +1, heart, hooray, and rocket reactions on an issue.
         minimum-upvotes-to-exempt: 5

--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -1,0 +1,37 @@
+---
+name: "Close Stale Issues"
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  issue-cleanup:
+    permissions:
+      issues: write
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    name: Stale issue
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@v6
+      with:
+        issue-types: issues
+        ancient-issue-message: This issue has not received any attention in 1 year. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        stale-issue-message: This issue has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        stale-issue-label: closing-soon
+        exempt-issue-labels: no-autoclose
+        response-requested-label: response-requested
+        # Don't set closed-for-staleness label to skip closing very old issues regardless of label
+        closed-for-staleness-label: closed-for-staleness
+        # Issue timing
+        days-before-stale: 5
+        days-before-close: 10
+        days-before-ancient: 365
+        # If you don't want to mark an issue as being ancient based on a threshold of "upvotes", you can set this here.
+        # An "upvote" is the total number of +1, heart, hooray, and rocket reactions on an issue.
+        minimum-upvotes-to-exempt: 5
+        loglevel: DEBUG
+        dry-run: false
+        repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: aws-actions/stale-issue-cleanup@v6
       with:
         issue-types: issues
-        ancient-issue-message: This issue has not received any attention in 1 year. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        ancient-issue-message: This issue has not received any attention in 30 days. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
         stale-issue-message: This issue has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
         stale-issue-label: closing-soon
         exempt-issue-labels: no-autoclose
@@ -28,7 +28,7 @@ jobs:
         # Issue timing
         days-before-stale: 7
         days-before-close: 14
-        days-before-ancient: 3
+        days-before-ancient: 30
         # If you don't want to mark an issue as being ancient based on a threshold of "upvotes", you can set this here.
         # An "upvote" is the total number of +1, heart, hooray, and rocket reactions on an issue.
         minimum-upvotes-to-exempt: 5


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
Adds a stale issue workflow with defined timelines to classify the  

Resolves: #118 

### Changes

- Adds a stale issue workflow to review open issues .

### User experience

- No impacts from the usage of eksupgrade
- Users with open issues will be scoped under this workflow.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [X] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
