### PR TITLE
fix: Workflow trigger bound to protected environment

### DIFF
--- a/.github/workflows/e2e-test-template.yaml
+++ b/.github/workflows/e2e-test-template.yaml
@@ -37,6 +37,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: dev
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -67,6 +68,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: dev
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -70,6 +70,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: dev
     strategy:
       matrix:
         include:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

- Updating the workflow trigger to use deployment environment `dev`.

### Changes

- Updated the cluster workflow to use a deployment environment `dev` than binding secrets to repository level.

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [X] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
