### PR TITLE
fix: Add feature request to be ignored for stale issues

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -21,7 +21,7 @@ jobs:
         ancient-issue-message: This issue has not received any attention in 30 days. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
         stale-issue-message: This issue has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
         stale-issue-label: closing-soon
-        exempt-issue-labels: no-autoclose
+        exempt-issue-labels: no-autoclose, feature-request
         response-requested-label: response-requested
         # Don't set closed-for-staleness label to skip closing very old issues regardless of label
         closed-for-staleness-label: closed-for-staleness


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary
Adds `feaure-request` as a label to ignore from issue staleness check.


### Changes

Added `feature-request` to the exempt-issue-labels to prevent stale bot from closing open feature requests.

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [X] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
