### PR TITLE
fix: Correct Poetry install script URL used in CI workflow

### DIFF
--- a/.github/actions/dep-setup/action.yml
+++ b/.github/actions/dep-setup/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
       run: |
         export POETRY_HOME=${{github.workspace}}/.poetry
-        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -O
+        curl -sSL https://install.python-poetry.org -o install-poetry.py
         python install-poetry.py --preview
         rm install-poetry.py
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

- Correct Poetry install script URL used in CI workflow

### Changes

- Updates the URL where the Poetry install script is located

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [ ] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
